### PR TITLE
feat(proxy): add DNS management and port 443 support

### DIFF
--- a/cmd/lokl/main.go
+++ b/cmd/lokl/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/proxy"
 	"github.com/shahin-bayat/lokl/internal/supervisor"
 	"github.com/shahin-bayat/lokl/internal/version"
 )
@@ -75,7 +76,59 @@ var statusCmd = &cobra.Command{
 	},
 }
 
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manage DNS entries",
+}
+
+var dnsSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Add DNS entries to /etc/hosts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load(configFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		p := proxy.New(cfg)
+		domains := p.Domains()
+
+		if len(domains) == 0 {
+			fmt.Println("No domains configured")
+			return nil
+		}
+
+		if err := p.SetupDNS(); err != nil {
+			return fmt.Errorf("adding DNS entries: %w", err)
+		}
+
+		fmt.Printf("✓ Added %d entries to /etc/hosts\n", len(domains))
+		return nil
+	},
+}
+
+var dnsRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove DNS entries from /etc/hosts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load(configFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		p := proxy.New(cfg)
+
+		if err := p.RemoveDNS(); err != nil {
+			return fmt.Errorf("removing DNS entries: %w", err)
+		}
+
+		fmt.Println("✓ Removed DNS entries from /etc/hosts")
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", defaultConfigFile, "config file path")
-	rootCmd.AddCommand(upCmd, downCmd, statusCmd)
+	dnsCmd.AddCommand(dnsSetupCmd, dnsRemoveCmd)
+	rootCmd.AddCommand(upCmd, downCmd, statusCmd, dnsCmd)
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -37,6 +37,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		http.Error(w, fmt.Sprintf("upstream error: %v", err), http.StatusBadGateway)
 	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		resp.Header.Set("X-Lokl-Proxy", "true")
+		return nil
+	}
 
 	// Preserve original host for backends that check it
 	r.Header.Set("X-Forwarded-Host", r.Host)


### PR DESCRIPTION
## Summary
- Add `lokl dns setup/remove` commands for managing /etc/hosts entries
- Bind proxy on `0.0.0.0:443` - no sudo required on macOS 10.14+ (discovered undocumented Apple change)
- Add DNS resolution check at startup with actionable error messages
- Fix clean process shutdown using `exec` trick + process groups
- Add `X-Lokl-Proxy` response header for debugging in DevTools

## Key Finding
On macOS Mojave (10.14+), non-root processes can bind to port 443 when using `0.0.0.0` as bind address. This eliminates the need for sudo during daily development.

## Test plan
- [ ] Run `lokl up` without DNS entries, verify helpful message shown
- [ ] Run `sudo lokl dns setup`, verify /etc/hosts updated
- [ ] Run `lokl up`, verify proxy starts on port 443
- [ ] Test app redirects work correctly on standard HTTPS port
- [ ] Verify Ctrl+C stops all processes cleanly
- [ ] Check `X-Lokl-Proxy` header in browser DevTools