### PR TITLE
feat(tui): add log viewer panel

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -46,6 +46,13 @@ func (p *Process) IsHealthy() bool {
 	return p.healthy
 }
 
+func (p *Process) Logs() []string {
+	if p.logs == nil {
+		return nil
+	}
+	return p.logs.Lines()
+}
+
 func (p *Process) Start() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -15,6 +15,7 @@ type ProcessRunner interface {
 	Stop() error
 	IsRunning() bool
 	IsHealthy() bool
+	Logs() []string
 }
 
 // ProcessFactory creates a new process runner.
@@ -168,6 +169,13 @@ func (s *Supervisor) Services() []types.ServiceInfo {
 
 func (s *Supervisor) ProjectName() string {
 	return s.cfg.Name
+}
+
+func (s *Supervisor) ServiceLogs(name string) []string {
+	if p, ok := s.processes[name]; ok {
+		return p.Logs()
+	}
+	return nil
 }
 
 func (s *Supervisor) setupProxy() error {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -8,6 +8,7 @@ type ServiceController interface {
 	StopService(name string) error
 	RestartService(name string) error
 	Services() []types.ServiceInfo
+	ServiceLogs(name string) []string
 	ProjectName() string
 }
 
@@ -16,6 +17,7 @@ type Model struct {
 	controller  ServiceController
 	services    []types.ServiceInfo
 	selectedIdx int
+	showLogs    bool
 	width       int
 	height      int
 	quitting    bool

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -68,6 +68,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if svc := m.selectedService(); svc != nil {
 			_ = m.controller.RestartService(svc.Name)
 		}
+
+	case "l":
+		m.showLogs = !m.showLogs
 	}
 
 	return m, nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -19,6 +19,11 @@ func (m Model) View() string {
 	b.WriteString(m.renderHeader())
 	b.WriteString("\n\n")
 	b.WriteString(m.renderServices())
+
+	if m.showLogs {
+		b.WriteString(m.renderLogs())
+	}
+
 	b.WriteString("\n")
 	b.WriteString(m.renderStatusBar())
 
@@ -112,12 +117,46 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool) string {
 	return row
 }
 
+func (m Model) renderLogs() string {
+	svc := m.selectedService()
+	if svc == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(styleDomain.Render(fmt.Sprintf("─── Logs: %s ", svc.Name)))
+	b.WriteString(styleDomain.Render(strings.Repeat("─", 40)))
+	b.WriteString("\n\n")
+
+	logs := m.controller.ServiceLogs(svc.Name)
+	if len(logs) == 0 {
+		b.WriteString(styleStopped.Render("  No logs available"))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	// Show last 10 lines
+	start := 0
+	if len(logs) > 10 {
+		start = len(logs) - 10
+	}
+	for _, line := range logs[start:] {
+		b.WriteString("  ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
 func (m Model) renderStatusBar() string {
 	keys := []string{
 		styleKeyHint.Render("j/k") + " navigate",
 		styleKeyHint.Render("s") + " start",
 		styleKeyHint.Render("x") + " stop",
 		styleKeyHint.Render("r") + " restart",
+		styleKeyHint.Render("l") + " logs",
 		styleKeyHint.Render("q") + " quit",
 	}
 


### PR DESCRIPTION
## Summary
- Toggle log panel with `l` key
- Shows last 10 lines of selected service logs
- Live updates every 200ms

## Changes
- `internal/process/process.go` - add Logs() method
- `internal/supervisor/supervisor.go` - add ServiceLogs(), Logs to ProcessRunner interface
- `internal/tui/` - log panel rendering, `l` key binding