### PR TITLE
feat(tui): replace polling with event-driven updates

### DIFF
--- a/cmd/lokl/main.go
+++ b/cmd/lokl/main.go
@@ -47,12 +47,12 @@ var upCmd = &cobra.Command{
 			return fmt.Errorf("loading config: %w", err)
 		}
 
-		processRunner := func(name string, svc config.Service) supervisor.ProcessRunner {
-			return process.New(name, svc)
+		processFactory := func(name string, svc config.Service, onChange func()) supervisor.ProcessRunner {
+			return process.New(name, svc, onChange)
 		}
 
 		log := logger.New(os.Stdout)
-		sup := supervisor.New(cfg, processRunner, proxy.New(cfg), log)
+		sup := supervisor.New(cfg, processFactory, proxy.New(cfg), log)
 
 		if err := sup.Start(); err != nil {
 			return err

--- a/internal/process/health.go
+++ b/internal/process/health.go
@@ -33,14 +33,22 @@ func (p *Process) startHealthCheck(ctx context.Context) {
 			if p.checkHealth(timeout) {
 				failures = 0
 				p.mu.Lock()
+				prev := p.healthy
 				p.healthy = true
 				p.mu.Unlock()
+				if !prev {
+					p.onChange()
+				}
 			} else {
 				failures++
 				if failures >= retries {
 					p.mu.Lock()
+					prev := p.healthy
 					p.healthy = false
 					p.mu.Unlock()
+					if prev {
+						p.onChange()
+					}
 				}
 			}
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,11 +11,13 @@ type ServiceController interface {
 	Services() []types.ServiceInfo
 	ServiceLogs(name string) []string
 	ProjectName() string
+	Subscribe() <-chan types.Event
 }
 
 // Model is the TUI state.
 type Model struct {
 	controller  ServiceController
+	events      <-chan types.Event
 	services    []types.ServiceInfo
 	selectedIdx int
 	showLogs    bool
@@ -27,6 +29,7 @@ type Model struct {
 func newModel(ctrl ServiceController) Model {
 	m := Model{
 		controller: ctrl,
+		events:     ctrl.Subscribe(),
 	}
 	m.refreshServices()
 	return m

--- a/internal/types/event.go
+++ b/internal/types/event.go
@@ -1,0 +1,15 @@
+package types
+
+// EventType represents the type of service event.
+type EventType int
+
+const (
+	EventServiceStateChanged EventType = iota
+	EventServiceHealthChanged
+)
+
+// Event represents a service state change notification.
+type Event struct {
+	Type    EventType
+	Service string
+}


### PR DESCRIPTION
## Summary

- Replace 200ms polling with event-driven updates for service state changes
- Add `onChange` callback to Process that fires on start/stop/crash/health changes
- Add event channel in Supervisor with `Subscribe()` method
- TUI now listens for events instead of polling
- Log polling remains (200ms) but only when log panel is visible

## Changes

- `internal/types/event.go` - New Event type
- `internal/process/process.go` - Add onChange callback
- `internal/process/health.go` - Emit event on health change
- `internal/supervisor/supervisor.go` - Event channel + Subscribe()
- `internal/tui/model.go` - Add Subscribe to ServiceController interface
- `internal/tui/update.go` - Event-driven updates + conditional log polling
- `cmd/lokl/main.go` - Update ProcessFactory signature

## Test plan

- [ ] Run `lokl up` and verify TUI updates on service start
- [ ] Stop a service and verify TUI updates immediately
- [ ] Toggle logs panel and verify log updates work
- [ ] Verify no CPU spike (no constant polling)