### PR TITLE
feat(cli): add lokl init command with Node.js detection

### DIFF
--- a/cmd/lokl/dns.go
+++ b/cmd/lokl/dns.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/proxy"
+)
+
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manage DNS entries",
+}
+
+var dnsSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Add DNS entries to /etc/hosts",
+	RunE:  runDNSSetup,
+}
+
+var dnsRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove DNS entries from /etc/hosts",
+	RunE:  runDNSRemove,
+}
+
+func init() {
+	dnsCmd.AddCommand(dnsSetupCmd, dnsRemoveCmd)
+}
+
+func runDNSSetup(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		return err
+	}
+
+	p := proxy.New(cfg)
+	domains := p.Domains()
+
+	if len(domains) == 0 {
+		fmt.Println("No domains configured")
+		return nil
+	}
+
+	if err := p.SetupDNS(); err != nil {
+		return fmt.Errorf("adding DNS entries: %w", err)
+	}
+
+	fmt.Printf("✓ Added %d entries to /etc/hosts\n", len(domains))
+	return nil
+}
+
+func runDNSRemove(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		return err
+	}
+
+	p := proxy.New(cfg)
+
+	if err := p.RemoveDNS(); err != nil {
+		return fmt.Errorf("removing DNS entries: %w", err)
+	}
+
+	fmt.Println("✓ Removed DNS entries from /etc/hosts")
+	fmt.Println("\nTo flush DNS cache:")
+	if runtime.GOOS == "darwin" {
+		fmt.Println("  sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder")
+	} else {
+		fmt.Println("  sudo systemd-resolve --flush-caches")
+	}
+	return nil
+}

--- a/cmd/lokl/init_cmd.go
+++ b/cmd/lokl/init_cmd.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/shahin-bayat/lokl/internal/inspect"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a new lokl.yaml from detected project structure",
+	RunE:  runInit,
+}
+
+type serviceConfig struct {
+	command string
+	port    int
+	path    string
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	if _, err := os.Stat(defaultConfigFile); err == nil {
+		fmt.Printf("lokl.yaml already exists. Overwrite? [y/N] ")
+		if !promptYesNo(false) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	fmt.Println("Scanning project...")
+	result, err := inspect.Inspect(cwd)
+	if err != nil {
+		return fmt.Errorf("inspecting project: %w", err)
+	}
+
+	if len(result.Services) == 0 {
+		fmt.Println("\nNo services detected.")
+		fmt.Println("Create lokl.yaml manually or ensure your project has package.json with scripts.")
+		return nil
+	}
+
+	fmt.Printf("\nDetected %d service(s):\n", len(result.Services))
+	for _, svc := range result.Services {
+		fmt.Printf("  - %s (%s)\n", svc.Name, svc.Path)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	services := make(map[string]serviceConfig)
+
+	for _, svc := range result.Services {
+		sc, ok := configureService(svc, cwd, scanner)
+		if ok {
+			services[svc.Name] = sc
+		}
+	}
+
+	if len(services) == 0 {
+		fmt.Println("\nNo services configured. Aborting.")
+		return nil
+	}
+
+	fmt.Printf("\nBase domain [%s]: ", result.SuggestedDomain)
+	domain := result.SuggestedDomain
+	if scanner.Scan() {
+		if text := strings.TrimSpace(scanner.Text()); text != "" {
+			domain = text
+		}
+	}
+
+	return saveConfig(result.ProjectName, domain, services)
+}
+
+func configureService(svc inspect.Service, cwd string, scanner *bufio.Scanner) (serviceConfig, bool) {
+	fmt.Printf("\n─── %s ───\n", svc.Name)
+
+	svcPath := svc.Path
+	if svcPath == "." {
+		svcPath = cwd
+	} else {
+		svcPath = filepath.Join(cwd, svc.Path)
+	}
+
+	scripts, err := inspect.GetScripts(svcPath)
+	if err != nil {
+		fmt.Printf("  Warning: could not read scripts: %v\n", err)
+		return serviceConfig{}, false
+	}
+
+	scriptNames := inspect.SortScriptsByPriority(scripts)
+
+	fmt.Println("  Available scripts:")
+	for i, name := range scriptNames {
+		fmt.Printf("    [%d] %s\n", i+1, name)
+	}
+	fmt.Printf("    [0] Skip this service\n")
+
+	fmt.Printf("  Select script [1]: ")
+	choice := 1
+	if scanner.Scan() {
+		if n, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil {
+			choice = n
+		}
+	}
+
+	if choice == 0 || choice > len(scriptNames) {
+		fmt.Printf("  Skipping %s\n", svc.Name)
+		return serviceConfig{}, false
+	}
+
+	selectedScript := scriptNames[choice-1]
+	scriptCmd := scripts[selectedScript]
+
+	port := inspect.InferPort(scriptCmd)
+	if port == 0 {
+		fmt.Printf("  Port (required): ")
+		if scanner.Scan() {
+			if n, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil {
+				port = n
+			}
+		}
+	} else {
+		fmt.Printf("  Port [%d]: ", port)
+		if scanner.Scan() {
+			if text := strings.TrimSpace(scanner.Text()); text != "" {
+				if n, err := strconv.Atoi(text); err == nil {
+					port = n
+				}
+			}
+		}
+	}
+
+	if port == 0 {
+		fmt.Printf("  Skipping %s (no port)\n", svc.Name)
+		return serviceConfig{}, false
+	}
+
+	sc := serviceConfig{
+		command: svc.Command + " run " + selectedScript,
+		port:    port,
+	}
+	if svc.Path != "." {
+		sc.path = svc.Path
+	}
+
+	return sc, true
+}
+
+func saveConfig(projectName, domain string, services map[string]serviceConfig) error {
+	svcMap := make(map[string]map[string]any)
+	for name, svc := range services {
+		m := map[string]any{
+			"command": svc.command,
+			"port":    svc.port,
+		}
+		if svc.path != "" {
+			m["path"] = svc.path
+		}
+		svcMap[name] = m
+	}
+
+	cfg := map[string]any{
+		"name":    projectName,
+		"version": "1",
+		"proxy": map[string]string{
+			"domain": domain,
+		},
+		"services": svcMap,
+	}
+
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(defaultConfigFile, data, 0644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	fmt.Printf("\n✓ Created %s\n", defaultConfigFile)
+	fmt.Println("✓ Run 'lokl up' to start your environment")
+
+	return nil
+}
+
+func promptYesNo(defaultYes bool) bool {
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		text := strings.ToLower(strings.TrimSpace(scanner.Text()))
+		if text == "y" || text == "yes" {
+			return true
+		}
+		if text == "n" || text == "no" {
+			return false
+		}
+	}
+	return defaultYes
+}

--- a/cmd/lokl/up.go
+++ b/cmd/lokl/up.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/logger"
+	"github.com/shahin-bayat/lokl/internal/process"
+	"github.com/shahin-bayat/lokl/internal/proxy"
+	"github.com/shahin-bayat/lokl/internal/supervisor"
+	"github.com/shahin-bayat/lokl/internal/tui"
+)
+
+var detach bool
+
+var upCmd = &cobra.Command{
+	Use:   "up [services...]",
+	Short: "Start the development environment",
+	RunE:  runUp,
+}
+
+func init() {
+	upCmd.Flags().BoolVarP(&detach, "detach", "d", false, "run without TUI")
+}
+
+func runUp(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		return err
+	}
+
+	processFactory := func(name string, svc config.Service, onChange func()) supervisor.ProcessRunner {
+		return process.New(name, svc, onChange)
+	}
+
+	log := logger.New(os.Stdout)
+	sup := supervisor.New(cfg, processFactory, proxy.New(cfg), log)
+
+	if err := sup.Start(); err != nil {
+		return err
+	}
+
+	if detach {
+		log.Infof("\nPress Ctrl+C to stop\n")
+		waitForSignal()
+		log.Infof("\nShutting down...\n")
+	} else {
+		app := tui.New(sup)
+		if err := app.Run(); err != nil {
+			_ = sup.Stop()
+			return err
+		}
+	}
+
+	return sup.Stop()
+}

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -1,0 +1,54 @@
+// Package inspect provides project detection for lokl init.
+package inspect
+
+import "path/filepath"
+
+// Service represents a detected service in the project.
+type Service struct {
+	Name      string
+	Path      string
+	Command   string
+	Port      int
+	AutoStart bool
+}
+
+// Result contains all detected project information.
+type Result struct {
+	ProjectName     string
+	Services        []Service
+	SuggestedDomain string
+}
+
+// inspector interface - each language/framework implements this.
+type inspector interface {
+	name() string
+	inspect(root string) ([]Service, error)
+}
+
+// registry of all inspectors
+var inspectors = []inspector{
+	&nodeInspector{},
+}
+
+// Inspect scans a project directory and returns detected services.
+func Inspect(root string) (*Result, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		ProjectName:     filepath.Base(absRoot),
+		SuggestedDomain: filepath.Base(absRoot) + ".dev",
+	}
+
+	for _, i := range inspectors {
+		services, err := i.inspect(absRoot)
+		if err != nil {
+			continue
+		}
+		result.Services = append(result.Services, services...)
+	}
+
+	return result, nil
+}

--- a/internal/inspect/node.go
+++ b/internal/inspect/node.go
@@ -1,0 +1,207 @@
+package inspect
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type nodeInspector struct{}
+
+func (n *nodeInspector) name() string { return "node" }
+
+func (n *nodeInspector) inspect(root string) ([]Service, error) {
+	// Entry check: is this a node project?
+	if _, err := os.Stat(filepath.Join(root, "package.json")); err != nil {
+		return nil, nil
+	}
+
+	pm := detectPackageManager(root)
+	var services []Service
+
+	// Walk tree to find all package.json files
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip errors
+		}
+
+		// Skip node_modules and hidden directories
+		if d.IsDir() {
+			name := d.Name()
+			if name == "node_modules" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.Name() != "package.json" {
+			return nil
+		}
+
+		svc := parsePackageJSON(path, root, pm)
+		if svc != nil {
+			services = append(services, *svc)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return services, nil
+}
+
+func detectPackageManager(root string) string {
+	lockfiles := []struct {
+		file string
+		pm   string
+	}{
+		{"pnpm-lock.yaml", "pnpm"},
+		{"yarn.lock", "yarn"},
+		{"bun.lockb", "bun"},
+		{"package-lock.json", "npm"},
+	}
+
+	for _, lf := range lockfiles {
+		if _, err := os.Stat(filepath.Join(root, lf.file)); err == nil {
+			return lf.pm
+		}
+	}
+	return "npm"
+}
+
+type packageJSON struct {
+	Name    string            `json:"name"`
+	Scripts map[string]string `json:"scripts"`
+}
+
+var portPattern = regexp.MustCompile(`(?:--port[=\s]|PORT=|-p\s?)(\d+)`)
+
+var devScriptPriority = map[string]int{
+	"dev":     1,
+	"develop": 2,
+	"start":   3,
+	"serve":   4,
+	"watch":   5,
+}
+
+// SortScriptsByPriority returns script names sorted with common dev scripts first.
+func SortScriptsByPriority(scripts map[string]string) []string {
+	names := make([]string, 0, len(scripts))
+	for name := range scripts {
+		names = append(names, name)
+	}
+
+	sort.Slice(names, func(i, j int) bool {
+		pi, pj := devScriptPriority[names[i]], devScriptPriority[names[j]]
+		if pi != pj {
+			if pi == 0 {
+				return false
+			}
+			if pj == 0 {
+				return true
+			}
+			return pi < pj
+		}
+		return names[i] < names[j]
+	})
+
+	return names
+}
+
+var defaultPorts = map[string]int{
+	"vite":      5173,
+	"next":      3000,
+	"nuxt":      3000,
+	"remix":     5173,
+	"astro":     4321,
+	"svelte":    5173,
+	"angular":   4200,
+	"gatsby":    8000,
+	"storybook": 6006,
+}
+
+// InferPort tries to extract port from a script command string.
+// First checks for explicit port flags, then falls back to known tool defaults.
+// Returns 0 if no port found.
+func InferPort(script string) int {
+	// Check explicit port flags first
+	matches := portPattern.FindStringSubmatch(script)
+	if len(matches) > 1 {
+		if port, err := strconv.Atoi(matches[1]); err == nil {
+			return port
+		}
+	}
+
+	// Fall back to known tool defaults
+	scriptLower := strings.ToLower(script)
+	for tool, port := range defaultPorts {
+		if strings.Contains(scriptLower, tool) {
+			return port
+		}
+	}
+
+	return 0
+}
+
+// GetScripts returns available npm scripts for a service path.
+// Returns map of script name to script command.
+func GetScripts(servicePath string) (map[string]string, error) {
+	pkgPath := filepath.Join(servicePath, "package.json")
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, err
+	}
+
+	return pkg.Scripts, nil
+}
+
+func parsePackageJSON(path, root, pm string) *Service {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+
+	// Must have at least one script to be runnable
+	if len(pkg.Scripts) == 0 {
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	relPath, _ := filepath.Rel(root, dir)
+	if relPath == "" {
+		relPath = "."
+	}
+
+	name := pkg.Name
+	if name == "" {
+		name = filepath.Base(dir)
+	}
+	// Strip scope from name (@org/pkg -> pkg)
+	if idx := strings.LastIndex(name, "/"); idx != -1 {
+		name = name[idx+1:]
+	}
+
+	return &Service{
+		Name:      name,
+		Path:      relPath,
+		Command:   pm, // just the package manager, init will append "run <script>"
+		Port:      0,
+		AutoStart: true,
+	}
+}


### PR DESCRIPTION
## Summary
- Add `lokl init` command that scans projects and generates `lokl.yaml`
- Node.js detection: finds package.json files, detects package manager, infers ports
- Interactive prompts for script selection and port confirmation
- Refactor cmd/lokl into separate files (main.go, up.go, dns.go, init_cmd.go)

## Test plan
- [x] Test with monorepo structure (apps/frontend, apps/api)
- [x] Test port inference from flags (--port, -p)
- [x] Test tool default ports (vite → 5173)
- [x] Verify clean YAML output