### PR TITLE
feat: add easy installation (install script + Homebrew tap)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,13 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^chore:"
+
+brews:
+  - repository:
+      owner: shahin-bayat
+      name: homebrew-tap
+    homepage: "https://github.com/shahin-bayat/lokl"
+    description: "Local development environment orchestrator"
+    license: "MIT"
+    install: |
+      bin.install "lokl"

--- a/README.md
+++ b/README.md
@@ -36,12 +36,26 @@ That's it. Frontend, backend, databases, HTTPS routing — all running.
 
 🔍 **Project detection** — `lokl init` scans your project and generates config
 
+## Installation
+
+**Homebrew (macOS/Linux):**
+```bash
+brew install shahin-bayat/tap/lokl
+```
+
+**One-liner:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/shahin-bayat/lokl/main/install.sh | bash
+```
+
+**Go install:**
+```bash
+go install github.com/shahin-bayat/lokl/cmd/lokl@latest
+```
+
 ## Quick Start
 
 ```bash
-# Install (macOS/Linux)
-go install github.com/shahin-bayat/lokl/cmd/lokl@latest
-
 # Initialize config from your project
 lokl init
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+REPO="shahin-bayat/lokl"
+BINARY_NAME="lokl"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+error() { echo -e "${RED}$1${NC}" >&2; exit 1; }
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+    linux|darwin) ;;
+    *) error "Unsupported OS: $OS (only linux and darwin supported)" ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64|amd64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) error "Unsupported architecture: $ARCH" ;;
+esac
+
+# Get version (from argument or latest)
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    info "Fetching latest version..."
+    VERSION=$(curl -sI "https://github.com/$REPO/releases/latest" | grep -i "^location:" | sed 's/.*tag\///' | tr -d '\r\n')
+    if [ -z "$VERSION" ]; then
+        error "Failed to fetch latest version"
+    fi
+fi
+info "Installing lokl $VERSION"
+
+# Determine install directory
+if [ -w "/usr/local/bin" ]; then
+    INSTALL_DIR="/usr/local/bin"
+elif [ -d "$HOME/.local/bin" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+else
+    mkdir -p "$HOME/.local/bin"
+    INSTALL_DIR="$HOME/.local/bin"
+    warn "Installing to $INSTALL_DIR (add to PATH if needed)"
+fi
+
+# Download URL
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/${BINARY_NAME}_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+info "Downloading from $DOWNLOAD_URL"
+
+# Create temp directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Download and extract
+if ! curl -sL "$DOWNLOAD_URL" | tar xz -C "$TMP_DIR" 2>/dev/null; then
+    error "Failed to download. Check if version $VERSION exists and has binaries."
+fi
+
+# Install binary
+if [ -f "$TMP_DIR/$BINARY_NAME" ]; then
+    mv "$TMP_DIR/$BINARY_NAME" "$INSTALL_DIR/"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+else
+    error "Binary not found in archive"
+fi
+
+# Verify
+if command -v lokl &>/dev/null; then
+    info "lokl $VERSION installed successfully to $INSTALL_DIR"
+    lokl --version
+else
+    warn "lokl installed to $INSTALL_DIR"
+    warn "Add $INSTALL_DIR to your PATH to use it"
+fi

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -5,10 +5,31 @@ description: How to install lokl
 
 ## Requirements
 
-- macOS or Linux
-- Go 1.23+ (for installation from source)
+- macOS or Linux (Windows not supported)
+
+## Homebrew (Recommended)
+
+```bash
+brew install shahin-bayat/tap/lokl
+```
+
+## One-liner Script
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shahin-bayat/lokl/main/install.sh | bash
+```
+
+This downloads the latest release and installs to `/usr/local/bin` (or `~/.local/bin` if no write access).
+
+To install a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shahin-bayat/lokl/main/install.sh | bash -s -- v0.1.0
+```
 
 ## Install from Source
+
+Requires Go 1.23+:
 
 ```bash
 go install github.com/shahin-bayat/lokl/cmd/lokl@latest


### PR DESCRIPTION
## Summary
- Add `install.sh` for one-liner installation
- Configure goreleaser to publish Homebrew formula
- Update README and docs with installation methods

## Installation Methods

**Homebrew:**
```bash
brew install shahin-bayat/tap/lokl
```

**One-liner:**
```bash
curl -fsSL https://raw.githubusercontent.com/shahin-bayat/lokl/main/install.sh | bash
```

## Test Plan
- [ ] Merge and create v0.1.1 tag
- [ ] Verify goreleaser creates binaries
- [ ] Verify formula appears in homebrew-tap
- [ ] Test `brew install shahin-bayat/tap/lokl`
- [ ] Test install script