### PR TITLE
fix(build): remove Windows target (Unix-only syscalls)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
@@ -23,11 +22,9 @@ builds:
       - -X github.com/shahin-bayat/lokl/internal/version.Version={{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
lokl uses Unix-only syscalls (Setpgid, Kill) that don't exist on Windows. Since lokl is Unix-only anyway, remove Windows from build targets.