### PR TITLE
fix(release): use PAT for homebrew tap push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ brews:
   - repository:
       owner: shahin-bayat
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/shahin-bayat/lokl"
     description: "Local development environment orchestrator"
     license: "MIT"


### PR DESCRIPTION
Use HOMEBREW_TAP_TOKEN secret for pushing formula to homebrew-tap repo.