### PR TITLE
fix: init scanner, TUI logs, DNS warning, subdomain prompt

### DIFF
--- a/cmd/lokl/init_cmd.go
+++ b/cmd/lokl/init_cmd.go
@@ -21,9 +21,10 @@ var initCmd = &cobra.Command{
 }
 
 type serviceConfig struct {
-	command string
-	port    int
-	path    string
+	command   string
+	port      int
+	path      string
+	subdomain string
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -147,9 +148,18 @@ func configureService(svc inspect.Service, cwd string, scanner *bufio.Scanner) (
 		return serviceConfig{}, false
 	}
 
+	subdomain := svc.Name
+	fmt.Printf("  Subdomain [%s]: ", subdomain)
+	if scanner.Scan() {
+		if text := strings.TrimSpace(scanner.Text()); text != "" {
+			subdomain = text
+		}
+	}
+
 	sc := serviceConfig{
-		command: svc.Command + " run " + selectedScript,
-		port:    port,
+		command:   svc.Command + " run " + selectedScript,
+		port:      port,
+		subdomain: subdomain,
 	}
 	if svc.Path != "." {
 		sc.path = svc.Path
@@ -162,8 +172,9 @@ func saveConfig(projectName, domain string, services map[string]serviceConfig) e
 	svcMap := make(map[string]map[string]any)
 	for name, svc := range services {
 		m := map[string]any{
-			"command": svc.command,
-			"port":    svc.port,
+			"command":   svc.command,
+			"port":      svc.port,
+			"subdomain": svc.subdomain,
 		}
 		if svc.path != "" {
 			m["path"] = svc.path

--- a/cmd/lokl/up.go
+++ b/cmd/lokl/up.go
@@ -36,7 +36,16 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 
 	log := logger.New(os.Stdout)
-	sup := supervisor.New(cfg, processFactory, proxy.New(cfg), log)
+	prx := proxy.New(cfg)
+
+	if cfg.Proxy.Domain != "" {
+		if unresolved := prx.UnresolvedDomains(); len(unresolved) > 0 {
+			log.Infof("⚠ DNS not configured for %s\n", cfg.Proxy.Domain)
+			log.Infof("  Run: sudo lokl dns setup\n\n")
+		}
+	}
+
+	sup := supervisor.New(cfg, processFactory, prx, log)
 
 	if err := sup.Start(); err != nil {
 		return err

--- a/internal/inspect/node.go
+++ b/internal/inspect/node.go
@@ -15,11 +15,6 @@ type nodeInspector struct{}
 func (n *nodeInspector) name() string { return "node" }
 
 func (n *nodeInspector) inspect(root string) ([]Service, error) {
-	// Entry check: is this a node project?
-	if _, err := os.Stat(filepath.Join(root, "package.json")); err != nil {
-		return nil, nil
-	}
-
 	pm := detectPackageManager(root)
 	var services []Service
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -133,10 +133,14 @@ func (m Model) renderLogs() string {
 		return b.String()
 	}
 
-	// Show last 10 lines
+	maxLogLines := m.height / 2
+	if maxLogLines < 3 {
+		maxLogLines = 3
+	}
+
 	start := 0
-	if len(logs) > 10 {
-		start = len(logs) - 10
+	if len(logs) > maxLogLines {
+		start = len(logs) - maxLogLines
 	}
 	for _, line := range logs[start:] {
 		b.WriteString("  ")


### PR DESCRIPTION
## Summary
- **Init scanner**: Scan subdirs even without root package.json
- **Init subdomain**: Prompt for subdomain with service name as default
- **TUI logs**: Use half terminal height instead of fixed 10 lines
- **DNS warning**: Show warning on `lokl up` when DNS not configured

## Test Plan
- [ ] `lokl init` in folder without root package.json
- [ ] `lokl init` prompts for subdomain
- [ ] `lokl up` shows DNS warning when subdomains configured but DNS not set
- [ ] TUI logs scale with terminal height