### PR TITLE
feat: add shell completions (bash/zsh/fish)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Build output
 /dist/
+/completions/
 
 # Runtime data
 .lokl/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,11 @@ project_name: lokl
 before:
   hooks:
     - go mod tidy
+    - go build -o lokl ./cmd/lokl
+    - mkdir -p completions
+    - ./lokl completion bash > completions/lokl.bash
+    - ./lokl completion zsh > completions/_lokl
+    - ./lokl completion fish > completions/lokl.fish
 
 builds:
   - main: ./cmd/lokl
@@ -47,3 +52,8 @@ brews:
     license: "MIT"
     install: |
       bin.install "lokl"
+      bash_completion.install "completions/lokl.bash" => "lokl"
+      zsh_completion.install "completions/_lokl"
+      fish_completion.install "completions/lokl.fish"
+    extra_files:
+      - glob: ./completions/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean install run fmt check
+.PHONY: build test lint clean install run fmt check completions
 
 BINARY=lokl
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -29,3 +29,9 @@ run:
 	go run ./cmd/lokl $(ARGS)
 
 check: fmt build test lint
+
+completions: build
+	@mkdir -p completions
+	./$(BINARY) completion bash > completions/lokl.bash
+	./$(BINARY) completion zsh > completions/_lokl
+	./$(BINARY) completion fish > completions/lokl.fish

--- a/cmd/lokl/completion.go
+++ b/cmd/lokl/completion.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish]",
+	Short:                 "Generate shell completion script",
+	ValidArgs:             []string{"bash", "zsh", "fish"},
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	Hidden:                true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletionV2(os.Stdout, true)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,46 @@ else
     error "Binary not found in archive"
 fi
 
+# Install shell completions
+install_completions() {
+    local shell_name="$1"
+    local lokl_bin="$INSTALL_DIR/$BINARY_NAME"
+
+    case "$shell_name" in
+        zsh)
+            local comp_dir="${ZDOTDIR:-$HOME}/.zsh/completions"
+            mkdir -p "$comp_dir"
+            "$lokl_bin" completion zsh > "$comp_dir/_lokl"
+            # Ensure fpath includes the directory
+            if ! grep -q 'fpath.*\.zsh/completions' ~/.zshrc 2>/dev/null; then
+                echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+                echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+            fi
+            ;;
+        bash)
+            local comp_dir="$HOME/.local/share/bash-completion/completions"
+            mkdir -p "$comp_dir"
+            "$lokl_bin" completion bash > "$comp_dir/lokl"
+            ;;
+        fish)
+            local comp_dir="$HOME/.config/fish/completions"
+            mkdir -p "$comp_dir"
+            "$lokl_bin" completion fish > "$comp_dir/lokl.fish"
+            ;;
+    esac
+}
+
+# Detect current shell and install completions
+CURRENT_SHELL=$(basename "$SHELL")
+if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+    case "$CURRENT_SHELL" in
+        zsh|bash|fish)
+            install_completions "$CURRENT_SHELL"
+            info "Shell completions installed for $CURRENT_SHELL"
+            ;;
+    esac
+fi
+
 # Verify
 if command -v lokl &>/dev/null; then
     info "lokl $VERSION installed successfully to $INSTALL_DIR"
@@ -79,4 +119,8 @@ if command -v lokl &>/dev/null; then
 else
     warn "lokl installed to $INSTALL_DIR"
     warn "Add $INSTALL_DIR to your PATH to use it"
+fi
+
+if [ "$CURRENT_SHELL" = "zsh" ]; then
+    info "Restart your shell or run: source ~/.zshrc"
 fi


### PR DESCRIPTION
## Summary
- Add hidden `lokl completion` command to generate shell scripts
- Homebrew formula auto-installs completions
- Install script auto-detects shell and installs completions
- Add `make completions` target

## Install paths
- **Homebrew**: auto via `bash_completion.install`, `zsh_completion.install`, `fish_completion.install`
- **Install script**: detects `$SHELL` and writes to appropriate config dir
- **Manual**: `lokl completion bash >> ~/.bashrc` (fallback)

## Test plan
- [ ] `./lokl completion bash` outputs valid bash completion
- [ ] `./lokl completion zsh` outputs valid zsh completion
- [ ] `./lokl completion fish` outputs valid fish completion
- [ ] `make completions` generates files in `completions/`
- [ ] Source completion and test: `source <(./lokl completion zsh) && lokl <TAB>`