### PR TITLE
fix(tui): include path prefix in displayed URL

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -229,6 +229,9 @@ func (s *Supervisor) Services() []types.ServiceInfo {
 		if domain := s.serviceDomain(svc); domain != "" {
 			item.Domain = domain
 			item.ProxyEnabled = s.proxyManager.IsProxyEnabled(domain)
+			if svc.Rewrite != nil && svc.Rewrite.StripPrefix != "" {
+				item.PathPrefix = "/" + svc.Rewrite.StripPrefix
+			}
 		}
 
 		if p, ok := s.processes[name]; ok {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -87,7 +87,7 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool) string {
 	if svc.Domain == "" {
 		domain = "  " + styleDomain.Render(fmt.Sprintf("%-30s", "-"))
 	} else {
-		url := fmt.Sprintf("https://%s", svc.Domain)
+		url := fmt.Sprintf("https://%s%s", svc.Domain, svc.PathPrefix)
 		paddedURL := fmt.Sprintf("%-30s", url)
 		if svc.ProxyEnabled {
 			domain = "  " + styleLink.Render(paddedURL)

--- a/internal/types/service.go
+++ b/internal/types/service.go
@@ -4,6 +4,7 @@ package types
 type ServiceInfo struct {
 	Name         string
 	Domain       string
+	PathPrefix   string
 	Port         int
 	Running      bool
 	Healthy      bool


### PR DESCRIPTION
## Summary
- Add PathPrefix field to ServiceInfo to pass strip_prefix from config to TUI
- Display full URL with path prefix (e.g., `https://app.example.dev/myapp` instead of just `https://app.example.dev`)

## Test plan
- [ ] Configure service with `rewrite.strip_prefix`
- [ ] Verify TUI shows full URL with path prefix
- [ ] Verify clicking/copying URL goes to correct path