### PR TITLE
feat(tui): UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Binary
 /lokl
 /lokl.exe

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ type Model struct {
 	selectedIdx int
 	showLogs    bool
 	logOffset   int // 0 = pinned to latest; >0 = scrolled up by N lines
+	logHOffset  int // horizontal scroll offset in runes
 	showHelp    bool
 	width       int
 	height      int

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/shahin-bayat/lokl/internal/types"
 )
@@ -98,5 +99,40 @@ func TestHeaderZeroRunningUsesStopped(t *testing.T) {
 	header := m.renderHeader()
 	if !strings.Contains(header, styleStopped.Render("0 running")) {
 		t.Errorf("header should contain styleStopped-rendered count when nothing running")
+	}
+}
+
+func TestLogSeparatorFillsWidth(t *testing.T) {
+	svc := types.ServiceInfo{Name: "api", Running: true, Healthy: true, Port: 3000}
+	m := newTestModel([]types.ServiceInfo{svc})
+	m.selectedIdx = 0
+	m.width = 80
+
+	output := m.renderLogs(20)
+	stripped := ansi.Strip(output)
+	lines := strings.Split(stripped, "\n")
+	var sepLine string
+	for _, l := range lines {
+		if strings.Contains(l, "─── Logs:") {
+			sepLine = l
+			break
+		}
+	}
+	if sepLine == "" {
+		t.Fatal("separator line not found in renderLogs output")
+	}
+	got := len([]rune(sepLine))
+	if got < m.width-2 || got > m.width {
+		t.Errorf("separator length %d not within [%d, %d]", got, m.width-2, m.width)
+	}
+}
+
+func TestStatusBarHasDivider(t *testing.T) {
+	m := newTestModel([]types.ServiceInfo{})
+	m.width = 80
+	bar := m.renderStatusBar()
+	stripped := ansi.Strip(bar)
+	if !strings.Contains(stripped, "─") {
+		t.Error("status bar should contain a ─ divider line")
 	}
 }

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -136,3 +136,28 @@ func TestStatusBarHasDivider(t *testing.T) {
 		t.Error("status bar should contain a ─ divider line")
 	}
 }
+
+func TestNameColumnAdaptsToLongestName(t *testing.T) {
+	svcs := []types.ServiceInfo{
+		{Name: "short", Running: true, Healthy: true},
+		{Name: "a-very-long-service-name", Running: false},
+	}
+	m := newTestModel(svcs)
+	m.width = 120
+
+	rendered := m.renderServices()
+	stripped := ansi.Strip(rendered)
+
+	if !strings.Contains(stripped, "a-very-long-service-name") {
+		t.Error("long service name should appear untruncated in service list")
+	}
+	if !strings.Contains(stripped, "short") {
+		t.Error("short service name should appear in service list")
+	}
+
+	// Verify both rows are present
+	lines := strings.Split(strings.TrimRight(stripped, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Errorf("expected at least 2 service rows, got %d", len(lines))
+	}
+}

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/shahin-bayat/lokl/internal/types"
+)
+
+func TestStyleProxyOffExists(t *testing.T) {
+	want := lipgloss.Color("#F4A227")
+	got := styleProxyOff.GetForeground()
+	if got != want {
+		t.Errorf("styleProxyOff foreground: want %q, got %q", want, got)
+	}
+}
+
+func TestStyleLinkColorIsLightPurple(t *testing.T) {
+	wantColor := lipgloss.Color("#A78BFA")
+	if styleLink.GetForeground() != wantColor {
+		t.Errorf("styleLink foreground: want %q, got %q", wantColor, styleLink.GetForeground())
+	}
+	if !styleLink.GetBold() {
+		t.Error("styleLink: expected bold")
+	}
+}
+
+func newTestModel(svcs []types.ServiceInfo) Model {
+	ctrl := &polishFakeController{svcs: svcs}
+	m := newModel(ctrl)
+	m.width = 120
+	return m
+}
+
+type polishFakeController struct{ svcs []types.ServiceInfo }
+
+func (f *polishFakeController) StartService(_ string) error        { return nil }
+func (f *polishFakeController) StopService(_ string) error         { return nil }
+func (f *polishFakeController) RestartService(_ string) error      { return nil }
+func (f *polishFakeController) ToggleProxy(_ string) (bool, error) { return false, nil }
+func (f *polishFakeController) Services() []types.ServiceInfo      { return f.svcs }
+func (f *polishFakeController) ServiceLogs(_ string) []string      { return nil }
+func (f *polishFakeController) ProjectName() string                { return "test" }
+func (f *polishFakeController) Subscribe() <-chan types.Event {
+	return make(chan types.Event)
+}
+
+func TestUnhealthyRowNotSelectedHasTint(t *testing.T) {
+	svc := types.ServiceInfo{Name: "api", Running: true, Healthy: false}
+	m := newTestModel([]types.ServiceInfo{svc})
+
+	row := m.renderServiceRow(svc, false, 16)
+	rowNoTint := m.renderServiceRow(types.ServiceInfo{Name: "api", Running: true, Healthy: true}, false, 16)
+	if row == rowNoTint {
+		t.Error("unhealthy unselected row should differ from healthy row (tint not applied)")
+	}
+}
+
+func TestUnhealthyRowSelectedNoTint(t *testing.T) {
+	svc := types.ServiceInfo{Name: "api", Running: true, Healthy: false}
+	m := newTestModel([]types.ServiceInfo{svc})
+
+	selectedRow := m.renderServiceRow(svc, true, 16)
+	unselectedRow := m.renderServiceRow(svc, false, 16)
+	if selectedRow == unselectedRow {
+		t.Error("selected and unselected rows should differ")
+	}
+}

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -65,5 +66,37 @@ func TestUnhealthyRowSelectedNoTint(t *testing.T) {
 	unselectedRow := m.renderServiceRow(svc, false, 16)
 	if selectedRow == unselectedRow {
 		t.Error("selected and unselected rows should differ")
+	}
+}
+
+func TestHeaderRunningCountStyled(t *testing.T) {
+	svc := types.ServiceInfo{Name: "api", Running: true, Healthy: true}
+	m := newTestModel([]types.ServiceInfo{svc})
+	m.width = 120
+
+	expectedColor := styleRunning.GetForeground()
+	if expectedColor == (lipgloss.Color("")) {
+		t.Skip("lipgloss has no color in test environment — verify manually")
+	}
+
+	header := m.renderHeader()
+	if !strings.Contains(header, styleRunning.Render("1 running")) {
+		t.Errorf("header should contain styleRunning-rendered count")
+	}
+}
+
+func TestHeaderZeroRunningUsesStopped(t *testing.T) {
+	svc := types.ServiceInfo{Name: "api", Running: false, Healthy: false}
+	m := newTestModel([]types.ServiceInfo{svc})
+	m.width = 120
+
+	expectedColor := styleStopped.GetForeground()
+	if expectedColor == (lipgloss.Color("")) {
+		t.Skip("lipgloss has no color in test environment — verify manually")
+	}
+
+	header := m.renderHeader()
+	if !strings.Contains(header, styleStopped.Render("0 running")) {
+		t.Errorf("header should contain styleStopped-rendered count when nothing running")
 	}
 }

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/shahin-bayat/lokl/internal/types"
 )
 
-func TestStyleProxyOffExists(t *testing.T) {
-	want := lipgloss.Color("#F4A227")
-	got := styleProxyOff.GetForeground()
-	if got != want {
-		t.Errorf("styleProxyOff foreground: want %q, got %q", want, got)
-	}
-}
-
 func TestStyleLinkColorIsLightPurple(t *testing.T) {
 	wantColor := lipgloss.Color("#A78BFA")
 	if styleLink.GetForeground() != wantColor {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,14 +8,16 @@ var (
 	colorError     = lipgloss.Color("#FF4757")
 	colorMuted     = lipgloss.Color("#626262")
 	colorHighlight = lipgloss.Color("#3D3D5C")
+	colorAmber     = lipgloss.Color("#F4A227")
 
 	styleHeader = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(colorPrimary)
 
-	styleRunning = lipgloss.NewStyle().Foreground(colorSuccess)
-	styleStopped = lipgloss.NewStyle().Foreground(colorMuted)
-	styleFailed  = lipgloss.NewStyle().Foreground(colorError)
+	styleRunning  = lipgloss.NewStyle().Foreground(colorSuccess)
+	styleStopped  = lipgloss.NewStyle().Foreground(colorMuted)
+	styleFailed   = lipgloss.NewStyle().Foreground(colorError)
+	styleProxyOff = lipgloss.NewStyle().Foreground(colorAmber)
 
 	styleSelected = lipgloss.NewStyle().
 			Background(colorHighlight).
@@ -32,7 +34,7 @@ var (
 			Foreground(colorMuted)
 
 	styleLink = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00BFFF")).
+			Foreground(lipgloss.Color("#A78BFA")).
 			Bold(true)
 )
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,12 +3,11 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	colorPrimary   = lipgloss.Color("#7D56F4")
-	colorSuccess   = lipgloss.Color("#73D216")
-	colorError     = lipgloss.Color("#FF4757")
-	colorMuted     = lipgloss.Color("#626262")
-	colorHighlight = lipgloss.Color("#3D3D5C")
-	colorAmber     = lipgloss.Color("#F4A227")
+	colorPrimary = lipgloss.Color("#7D56F4")
+	colorSuccess = lipgloss.Color("#73D216")
+	colorError   = lipgloss.Color("#FF4757")
+	colorMuted   = lipgloss.Color("#626262")
+	colorAmber   = lipgloss.Color("#F4A227")
 
 	styleHeader = lipgloss.NewStyle().
 			Bold(true).
@@ -18,10 +17,6 @@ var (
 	styleStopped  = lipgloss.NewStyle().Foreground(colorMuted)
 	styleFailed   = lipgloss.NewStyle().Foreground(colorError)
 	styleProxyOff = lipgloss.NewStyle().Foreground(colorAmber)
-
-	styleSelected = lipgloss.NewStyle().
-			Background(colorHighlight).
-			Bold(true)
 
 	styleStatusBar = lipgloss.NewStyle().
 			Foreground(colorMuted)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -7,16 +7,14 @@ var (
 	colorSuccess = lipgloss.Color("#73D216")
 	colorError   = lipgloss.Color("#FF4757")
 	colorMuted   = lipgloss.Color("#626262")
-	colorAmber   = lipgloss.Color("#F4A227")
 
 	styleHeader = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(colorPrimary)
 
-	styleRunning  = lipgloss.NewStyle().Foreground(colorSuccess)
-	styleStopped  = lipgloss.NewStyle().Foreground(colorMuted)
-	styleFailed   = lipgloss.NewStyle().Foreground(colorError)
-	styleProxyOff = lipgloss.NewStyle().Foreground(colorAmber)
+	styleRunning = lipgloss.NewStyle().Foreground(colorSuccess)
+	styleStopped = lipgloss.NewStyle().Foreground(colorMuted)
+	styleFailed  = lipgloss.NewStyle().Foreground(colorError)
 
 	styleStatusBar = lipgloss.NewStyle().
 			Foreground(colorMuted)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -91,6 +91,24 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case "h", "left":
+		if m.showLogs && m.logHOffset > 0 {
+			m.logHOffset -= 4
+			if m.logHOffset < 0 {
+				m.logHOffset = 0
+			}
+		}
+
+	case "l", "right":
+		if m.showLogs {
+			m.logHOffset += 4
+		} else {
+			m.showLogs = true
+			m.logOffset = 0
+			m.logHOffset = 0
+			return m, logTick()
+		}
+
 	case "s":
 		if svc := m.selectedService(); svc != nil {
 			_ = m.controller.StartService(svc.Name)
@@ -112,17 +130,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.refreshServices()
 		}
 
-	case "l":
-		m.showLogs = !m.showLogs
-		m.logOffset = 0
-		if m.showLogs {
-			return m, logTick()
-		}
-
 	case "esc":
 		if m.showLogs {
 			m.showLogs = false
 			m.logOffset = 0
+			m.logHOffset = 0
 		}
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -88,10 +88,16 @@ func (m Model) renderServices() string {
 		return styleStopped.Render("  No services configured")
 	}
 
-	var b strings.Builder
+	nameWidth := 16
+	for _, svc := range m.services {
+		if len(svc.Name) > nameWidth {
+			nameWidth = len(svc.Name)
+		}
+	}
 
+	var b strings.Builder
 	for i, svc := range m.services {
-		line := m.renderServiceRow(svc, i == m.selectedIdx, 16)
+		line := m.renderServiceRow(svc, i == m.selectedIdx, nameWidth)
 		b.WriteString(line)
 		b.WriteString("\n")
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -123,7 +123,8 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth 
 		if svc.ProxyEnabled {
 			domain = "  " + styleLink.Render(paddedURL)
 		} else {
-			domain = styleProxyOff.Render("⊘") + " " + styleDomain.Render(paddedURL)
+			localURL := fmt.Sprintf("%-30s", fmt.Sprintf("http://localhost:%d", svc.Port))
+			domain = "  " + styleDomain.Render(localURL)
 		}
 	}
 
@@ -142,15 +143,12 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth 
 	}
 	status = statusStyle.Render(status)
 
-	row := fmt.Sprintf("%s%s %s %s  %s  %s", cursor, indicator, name, domain, port, status)
+	body := fmt.Sprintf("%s %s %s  %s  %s", indicator, name, domain, port, status)
 
-	if selected {
-		return styleSelected.Render(row)
+	if svc.Running && !svc.Healthy && !selected {
+		return cursor + lipgloss.NewStyle().Background(lipgloss.Color("#3D1E1E")).Render(body)
 	}
-	if svc.Running && !svc.Healthy {
-		return lipgloss.NewStyle().Background(lipgloss.Color("#3D1E1E")).Render(row)
-	}
-	return row
+	return cursor + body
 }
 
 func (m Model) renderLogs(available int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -69,7 +69,11 @@ func (m Model) renderHeader() string {
 	}
 
 	left := styleHeader.Render(name)
-	right := fmt.Sprintf("%s %d running", stateIndicator(runningCount > 0, true), runningCount)
+	countStyle := styleStopped
+	if runningCount > 0 {
+		countStyle = styleRunning
+	}
+	right := fmt.Sprintf("%s %s", stateIndicator(runningCount > 0, true), countStyle.Render(fmt.Sprintf("%d running", runningCount)))
 
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 0 {
@@ -98,7 +102,7 @@ func (m Model) renderServices() string {
 func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth int) string {
 	cursor := "  "
 	if selected {
-		cursor = styleKeyHint.Render("▸ ")
+		cursor = styleKeyHint.Render("❯ ")
 	}
 
 	indicator := stateIndicator(svc.Running, svc.Healthy)
@@ -113,7 +117,7 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth 
 		if svc.ProxyEnabled {
 			domain = "  " + styleLink.Render(paddedURL)
 		} else {
-			domain = styleProxyOff.Render("↗") + " " + styleDomain.Render(paddedURL)
+			domain = styleProxyOff.Render("⊘") + " " + styleDomain.Render(paddedURL)
 		}
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -153,10 +153,9 @@ func (m Model) renderLogs(available int) string {
 		return ""
 	}
 
-	headerStr := "\n" +
-		styleDomain.Render(fmt.Sprintf("─── Logs: %s ", svc.Name)) +
-		styleDomain.Render(strings.Repeat("─", 40)) +
-		"\n\n"
+	prefix := fmt.Sprintf("─── Logs: %s ", svc.Name)
+	fill := max(0, m.width-lipgloss.Width(prefix))
+	headerStr := "\n" + styleDomain.Render(prefix+strings.Repeat("─", fill)) + "\n\n"
 
 	logs := m.controller.ServiceLogs(svc.Name)
 	if len(logs) == 0 {
@@ -202,6 +201,8 @@ func (m Model) renderLogs(available int) string {
 }
 
 func (m Model) renderStatusBar() string {
+	divider := styleDomain.Render(strings.Repeat("─", m.width))
+
 	var keys []string
 	if m.showLogs {
 		keys = []string{
@@ -223,7 +224,7 @@ func (m Model) renderStatusBar() string {
 		}
 	}
 
-	return styleStatusBar.Render(strings.Join(keys, "  "))
+	return divider + "\n" + styleStatusBar.Render(strings.Join(keys, "  "))
 }
 
 func (m Model) renderHelp() string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -90,8 +90,8 @@ func (m Model) renderServices() string {
 
 	nameWidth := 16
 	for _, svc := range m.services {
-		if len(svc.Name) > nameWidth {
-			nameWidth = len(svc.Name)
+		if n := len([]rune(svc.Name)); n > nameWidth {
+			nameWidth = n
 		}
 	}
 
@@ -190,7 +190,7 @@ func (m Model) renderLogs(available int) string {
 		start = 0
 	}
 
-	logWidth := m.width - 2
+	logWidth := max(0, m.width-2)
 
 	var b strings.Builder
 	b.WriteString(headerStr)
@@ -203,6 +203,9 @@ func (m Model) renderLogs(available int) string {
 		hEnd := hStart + logWidth
 		if hEnd > len(runes) {
 			hEnd = len(runes)
+		}
+		if hEnd < hStart {
+			hEnd = hStart
 		}
 		b.WriteString("  ")
 		b.WriteString(string(runes[hStart:hEnd]))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -87,7 +87,7 @@ func (m Model) renderServices() string {
 	var b strings.Builder
 
 	for i, svc := range m.services {
-		line := m.renderServiceRow(svc, i == m.selectedIdx)
+		line := m.renderServiceRow(svc, i == m.selectedIdx, 16)
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
@@ -95,14 +95,14 @@ func (m Model) renderServices() string {
 	return b.String()
 }
 
-func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool) string {
+func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth int) string {
 	cursor := "  "
 	if selected {
 		cursor = styleKeyHint.Render("▸ ")
 	}
 
 	indicator := stateIndicator(svc.Running, svc.Healthy)
-	name := fmt.Sprintf("%-16s", svc.Name)
+	name := fmt.Sprintf("%-*s", nameWidth, svc.Name)
 
 	var domain string
 	if svc.Domain == "" {
@@ -113,7 +113,7 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool) string {
 		if svc.ProxyEnabled {
 			domain = "  " + styleLink.Render(paddedURL)
 		} else {
-			domain = styleFailed.Render("↗") + " " + styleDomain.Render(paddedURL)
+			domain = styleProxyOff.Render("↗") + " " + styleDomain.Render(paddedURL)
 		}
 	}
 
@@ -135,9 +135,11 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool) string {
 	row := fmt.Sprintf("%s%s %s %s  %s  %s", cursor, indicator, name, domain, port, status)
 
 	if selected {
-		row = styleSelected.Render(row)
+		return styleSelected.Render(row)
 	}
-
+	if svc.Running && !svc.Healthy {
+		return lipgloss.NewStyle().Background(lipgloss.Color("#3D1E1E")).Render(row)
+	}
 	return row
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -195,9 +195,17 @@ func (m Model) renderLogs(available int) string {
 	var b strings.Builder
 	b.WriteString(headerStr)
 	for _, line := range logs[start:end] {
-		line = sanitizeLog(line)
+		runes := []rune(sanitizeLog(line))
+		hStart := m.logHOffset
+		if hStart > len(runes) {
+			hStart = len(runes)
+		}
+		hEnd := hStart + logWidth
+		if hEnd > len(runes) {
+			hEnd = len(runes)
+		}
 		b.WriteString("  ")
-		b.WriteString(ansi.Truncate(line, logWidth, ""))
+		b.WriteString(string(runes[hStart:hEnd]))
 		b.WriteString("\n")
 	}
 
@@ -210,9 +218,9 @@ func (m Model) renderStatusBar() string {
 	var keys []string
 	if m.showLogs {
 		keys = []string{
-			styleKeyHint.Render("k") + " scroll up",
-			styleKeyHint.Render("j") + " scroll down",
-			styleKeyHint.Render("l/esc") + " close logs",
+			styleKeyHint.Render("k/j/↑/↓") + " scroll",
+			styleKeyHint.Render("h/l/←/→") + " pan",
+			styleKeyHint.Render("esc") + " close",
 			styleKeyHint.Render("q") + " quit",
 		}
 	} else {
@@ -244,7 +252,10 @@ func (m Model) renderHelp() string {
 		{"x", "Stop selected service"},
 		{"r", "Restart selected service"},
 		{"p", "Toggle proxy (local/remote)"},
-		{"l", "Toggle log view"},
+		{"l", "Open log view"},
+		{"k/j", "Scroll logs up/down (↑/↓)"},
+		{"h/l", "Pan logs left/right (←/→)"},
+		{"esc", "Close log view"},
 		{"?", "Show/hide this help"},
 		{"q", "Quit lokl"},
 	}


### PR DESCRIPTION
## Summary
- Log separator fills terminal width (was hardcoded 40 dashes)
- Thin `─` divider line above status bar for visual separation
- Proxy-off indicator changed from red `↗` to amber `⊘` — not an error state
- Link color changed from `#00BFFF` to `#A78BFA` (matches purple palette)
- Header running count styled with `styleRunning`/`styleStopped`
- Unhealthy unselected rows get a subtle dark red background tint (`#3D1E1E`)
- Service name column width adapts to longest name (no more fixed 16-char column)
- Cursor `▸` → `❯`, proxy-off symbol `↗` → `⊘`

## Test plan
- [ ] `go test ./internal/tui/...` passes (9 tests)
- [ ] `make test` passes
- [ ] Run `./lokl up` and verify visual improvements