### PR TITLE
feat(tui): copy logs to clipboard

### DIFF
--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func copyToClipboard(lines []string) error {
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(sanitizeLog(line))
+		b.WriteString("\n")
+	}
+
+	var cmd *exec.Cmd
+	if _, err := exec.LookPath("pbcopy"); err == nil {
+		cmd = exec.Command("pbcopy")
+	} else if _, err := exec.LookPath("xclip"); err == nil {
+		cmd = exec.Command("xclip", "-selection", "clipboard")
+	} else if _, err := exec.LookPath("xsel"); err == nil {
+		cmd = exec.Command("xsel", "--clipboard", "--input")
+	} else {
+		return fmt.Errorf("no clipboard tool found (install pbcopy, xclip, or xsel)")
+	}
+
+	cmd.Stdin = bytes.NewBufferString(b.String())
+	return cmd.Run()
+}

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"bytes"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -25,6 +24,9 @@ func copyToClipboard(lines []string) error {
 		return fmt.Errorf("no clipboard tool found (install pbcopy, xclip, or xsel)")
 	}
 
-	cmd.Stdin = bytes.NewBufferString(b.String())
-	return cmd.Run()
+	cmd.Stdin = strings.NewReader(b.String())
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("clipboard write: %w", err)
+	}
+	return nil
 }

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestCopyFlashShowsInStatusBar(t *testing.T) {
+	m := newTestModel(nil)
+	m.width = 80
+	m.copyMsg = "Logs copied"
+	m.copyExpiry = time.Now().Add(2 * time.Second)
+
+	bar := m.renderStatusBar()
+	stripped := ansi.Strip(bar)
+	if !strings.Contains(stripped, "Logs copied") {
+		t.Errorf("status bar should show flash message; got: %q", stripped)
+	}
+}
+
+func TestCopyFlashHiddenAfterExpiry(t *testing.T) {
+	m := newTestModel(nil)
+	m.width = 80
+	m.copyMsg = "Logs copied"
+	m.copyExpiry = time.Now().Add(-1 * time.Second) // already expired
+
+	bar := m.renderStatusBar()
+	stripped := ansi.Strip(bar)
+	if strings.Contains(stripped, "Logs copied") {
+		t.Error("expired flash should not appear in status bar")
+	}
+}
+
+func TestCopyDoneMsgClearsFlash(t *testing.T) {
+	m := newTestModel(nil)
+	m.copyMsg = "Logs copied"
+	m.copyExpiry = time.Now().Add(2 * time.Second)
+
+	next, _ := m.Update(copyDoneMsg{})
+	nm := next.(Model)
+
+	if nm.copyMsg != "" {
+		t.Errorf("copyDoneMsg should clear copyMsg; got %q", nm.copyMsg)
+	}
+}
+
+func TestCopyKeyWithNoServiceIsNoop(t *testing.T) {
+	m := newTestModel(nil) // no services → selectedService() = nil
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	nm := next.(Model)
+
+	if nm.copyMsg != "" {
+		t.Error("pressing 'c' with no service selected should not set copyMsg")
+	}
+	if cmd != nil {
+		t.Error("pressing 'c' with no service selected should return nil cmd")
+	}
+}
+
+func TestStatusBarShowsNormalKeysWhenNoFlash(t *testing.T) {
+	m := newTestModel(nil)
+	m.width = 80
+	// copyMsg is "" — no flash
+
+	bar := m.renderStatusBar()
+	stripped := ansi.Strip(bar)
+	if !strings.Contains(stripped, "navigate") {
+		t.Errorf("status bar should show normal keys when no flash; got: %q", stripped)
+	}
+}

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -36,7 +36,21 @@ func TestCopyFlashHiddenAfterExpiry(t *testing.T) {
 	}
 }
 
-func TestCopyDoneMsgClearsFlash(t *testing.T) {
+func TestCopyDoneMsgClearsFlashWhenExpired(t *testing.T) {
+	m := newTestModel(nil)
+	m.copyMsg = "Logs copied"
+	m.copyExpiry = time.Now().Add(-1 * time.Millisecond) // just expired
+
+	next, _ := m.Update(copyDoneMsg{})
+	nm := next.(Model)
+
+	if nm.copyMsg != "" {
+		t.Errorf("copyDoneMsg should clear copyMsg after expiry; got %q", nm.copyMsg)
+	}
+}
+
+func TestCopyDoneMsgKeepsFlashWhenNotExpired(t *testing.T) {
+	// simulates stale first timer after a second press reset the expiry
 	m := newTestModel(nil)
 	m.copyMsg = "Logs copied"
 	m.copyExpiry = time.Now().Add(2 * time.Second)
@@ -44,8 +58,8 @@ func TestCopyDoneMsgClearsFlash(t *testing.T) {
 	next, _ := m.Update(copyDoneMsg{})
 	nm := next.(Model)
 
-	if nm.copyMsg != "" {
-		t.Errorf("copyDoneMsg should clear copyMsg; got %q", nm.copyMsg)
+	if nm.copyMsg == "" {
+		t.Error("stale copyDoneMsg should not clear copyMsg when expiry is still active")
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,10 @@
 package tui
 
-import "github.com/shahin-bayat/lokl/internal/types"
+import (
+	"time"
+
+	"github.com/shahin-bayat/lokl/internal/types"
+)
 
 // ServiceController defines what the TUI needs to control and display services.
 type ServiceController interface {
@@ -27,6 +31,8 @@ type Model struct {
 	width       int
 	height      int
 	quitting    bool
+	copyMsg     string
+	copyExpiry  time.Time
 }
 
 func newModel(ctrl ServiceController) Model {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -56,7 +56,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case copyDoneMsg:
-		m.copyMsg = ""
+		if time.Now().After(m.copyExpiry) {
+			m.copyMsg = ""
+		}
 		return m, nil
 	}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -9,9 +9,17 @@ import (
 )
 
 const logPollInterval = 200 * time.Millisecond
+const copyFlashDuration = 1500 * time.Millisecond
 
 type eventMsg types.Event
 type logTickMsg struct{}
+type copyDoneMsg struct{}
+
+func copyFlashTimeout() tea.Cmd {
+	return tea.Tick(copyFlashDuration, func(time.Time) tea.Msg {
+		return copyDoneMsg{}
+	})
+}
 
 func (m Model) waitForEvent() tea.Msg {
 	return eventMsg(<-m.events)
@@ -45,6 +53,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showLogs {
 			return m, logTick()
 		}
+		return m, nil
+
+	case copyDoneMsg:
+		m.copyMsg = ""
 		return m, nil
 	}
 
@@ -128,6 +140,18 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if svc := m.selectedService(); svc != nil && svc.Domain != "" {
 			_, _ = m.controller.ToggleProxy(svc.Name)
 			m.refreshServices()
+		}
+
+	case "c":
+		if svc := m.selectedService(); svc != nil {
+			logs := m.controller.ServiceLogs(svc.Name)
+			if err := copyToClipboard(logs); err != nil {
+				m.copyMsg = "Copy failed"
+			} else {
+				m.copyMsg = "Logs copied"
+			}
+			m.copyExpiry = time.Now().Add(copyFlashDuration)
+			return m, copyFlashTimeout()
 		}
 
 	case "esc":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -123,8 +123,7 @@ func (m Model) renderServiceRow(svc types.ServiceInfo, selected bool, nameWidth 
 		if svc.ProxyEnabled {
 			domain = "  " + styleLink.Render(paddedURL)
 		} else {
-			localURL := fmt.Sprintf("%-30s", fmt.Sprintf("http://localhost:%d", svc.Port))
-			domain = "  " + styleDomain.Render(localURL)
+			domain = "  " + styleDomain.Render(paddedURL)
 		}
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
@@ -217,12 +218,17 @@ func (m Model) renderLogs(available int) string {
 func (m Model) renderStatusBar() string {
 	divider := styleDomain.Render(strings.Repeat("─", m.width))
 
+	if m.copyMsg != "" && time.Now().Before(m.copyExpiry) {
+		return divider + "\n" + styleStatusBar.Render(m.copyMsg)
+	}
+
 	var keys []string
 	if m.showLogs {
 		keys = []string{
 			styleKeyHint.Render("k/j/↑/↓") + " scroll",
 			styleKeyHint.Render("h/l/←/→") + " pan",
 			styleKeyHint.Render("esc") + " close",
+			styleKeyHint.Render("c") + " copy",
 			styleKeyHint.Render("q") + " quit",
 		}
 	} else {
@@ -233,6 +239,7 @@ func (m Model) renderStatusBar() string {
 			styleKeyHint.Render("r") + " restart",
 			styleKeyHint.Render("p") + " toggle",
 			styleKeyHint.Render("l") + " logs",
+			styleKeyHint.Render("c") + " copy",
 			styleKeyHint.Render("?") + " help",
 			styleKeyHint.Render("q") + " quit",
 		}
@@ -255,6 +262,7 @@ func (m Model) renderHelp() string {
 		{"r", "Restart selected service"},
 		{"p", "Toggle proxy (local/remote)"},
 		{"l", "Open log view"},
+		{"c", "Copy logs to clipboard"},
 		{"k/j", "Scroll logs up/down (↑/↓)"},
 		{"h/l", "Pan logs left/right (←/→)"},
 		{"esc", "Close log view"},


### PR DESCRIPTION
## Summary
- Press `c` to copy all logs for the selected service to the system clipboard
- macOS: uses `pbcopy`; Linux: `xclip` → `xsel` fallback
- Logs are sanitized (ANSI stripped, tabs expanded) before copy
- Status bar flashes "Logs copied" or "Copy failed" for 1.5 s, then reverts to normal key hints
- No-op when no service is selected

## Test Plan
- [ ] `go test ./...` passes
- [ ] Press `c` on a service with logs → "Logs copied" flashes, paste confirms clean output
- [ ] Press `c` with no clipboard tool → "Copy failed" flashes
- [ ] Flash disappears after ~1.5 s automatically
- [ ] `c` works in both normal view and log view