### PR TITLE
feat(notifications): desktop notifications on crash

### DIFF
--- a/cmd/lokl/up.go
+++ b/cmd/lokl/up.go
@@ -79,12 +79,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 
 	runners := make(map[string]supervisor.ProcessRunner)
-	pf := func(name string, svc config.Service, onChange func()) supervisor.ProcessRunner {
+	pf := func(name string, svc config.Service, onChange func(), onCrash func()) supervisor.ProcessRunner {
 		var r supervisor.ProcessRunner
 		if svc.Image != "" {
-			r = docker.NewContainer(name, svc, dockerClient, projectNetwork, onChange)
+			r = docker.NewContainer(name, svc, dockerClient, projectNetwork, onChange, onCrash)
 		} else {
-			r = process.New(name, svc, onChange)
+			r = process.New(name, svc, onChange, onCrash)
 		}
 		runners[name] = r
 		return r

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -77,6 +77,7 @@ func (c *Container) Start() error {
 		c.mu.Unlock()
 		return fmt.Errorf("container %s: cannot start from state %s", c.name, c.state)
 	}
+	c.manuallyStopped = false
 	c.state = runner.StateStarting
 	c.logs = runner.NewLogs(maxLogLines)
 	c.mu.Unlock()
@@ -166,24 +167,26 @@ func (c *Container) Start() error {
 			}
 			return err == nil && code == 0
 		}, interval, retries, func(healthy bool) {
-			if !healthy {
-				c.onCrash()
-			}
 			c.mu.Lock()
+			wasHealthy := c.healthy
 			c.healthy = healthy
 			c.mu.Unlock()
+			if !healthy && wasHealthy {
+				c.onCrash()
+			}
 			c.onChange()
 		})
 
 	case c.config.Health != nil && c.config.Health.Path != "":
 		interval, timeout, retries := parseHealthParams(c.config.Health)
 		go runner.RunHealthCheck(runCtx, c.config.Port, c.config.Health.Path, interval, timeout, retries, func(healthy bool) {
-			if !healthy {
-				c.onCrash()
-			}
 			c.mu.Lock()
+			wasHealthy := c.healthy
 			c.healthy = healthy
 			c.mu.Unlock()
+			if !healthy && wasHealthy {
+				c.onCrash()
+			}
 			c.onChange()
 		})
 
@@ -262,7 +265,7 @@ func (c *Container) watchContainer(ctx context.Context, containerID string) {
 			running, err := c.api.IsContainerRunning(ctx, containerID)
 			if err != nil || !running {
 				c.mu.Lock()
-				shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+				shouldNotify := !c.manuallyStopped && c.state == runner.StateRunning
 				if c.state == runner.StateRunning {
 					c.state = runner.StateFailed
 					c.healthy = false

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -31,14 +31,16 @@ type Container struct {
 	state    runner.State
 	healthy  bool
 	onChange func()
+	onCrash  func()
 
-	containerID string
-	logs        *runner.Logs
-	cancel      context.CancelFunc
-	mu          sync.Mutex
+	manuallyStopped bool
+	containerID     string
+	logs            *runner.Logs
+	cancel          context.CancelFunc
+	mu              sync.Mutex
 }
 
-func NewContainer(name string, cfg config.Service, api DockerAPI, network string, onChange func()) *Container {
+func NewContainer(name string, cfg config.Service, api DockerAPI, network string, onChange func(), onCrash func()) *Container {
 	return &Container{
 		name:     name,
 		config:   cfg,
@@ -46,6 +48,7 @@ func NewContainer(name string, cfg config.Service, api DockerAPI, network string
 		network:  network,
 		state:    runner.StateStopped,
 		onChange: onChange,
+		onCrash:  onCrash,
 	}
 }
 
@@ -163,6 +166,9 @@ func (c *Container) Start() error {
 			}
 			return err == nil && code == 0
 		}, interval, retries, func(healthy bool) {
+			if !healthy {
+				c.onCrash()
+			}
 			c.mu.Lock()
 			c.healthy = healthy
 			c.mu.Unlock()
@@ -172,6 +178,9 @@ func (c *Container) Start() error {
 	case c.config.Health != nil && c.config.Health.Path != "":
 		interval, timeout, retries := parseHealthParams(c.config.Health)
 		go runner.RunHealthCheck(runCtx, c.config.Port, c.config.Health.Path, interval, timeout, retries, func(healthy bool) {
+			if !healthy {
+				c.onCrash()
+			}
 			c.mu.Lock()
 			c.healthy = healthy
 			c.mu.Unlock()
@@ -194,6 +203,7 @@ func (c *Container) Stop() error {
 		c.mu.Unlock()
 		return nil
 	}
+	c.manuallyStopped = true
 	c.state = runner.StateStopping
 	c.healthy = false
 	id := c.containerID
@@ -252,11 +262,15 @@ func (c *Container) watchContainer(ctx context.Context, containerID string) {
 			running, err := c.api.IsContainerRunning(ctx, containerID)
 			if err != nil || !running {
 				c.mu.Lock()
+				shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
 				if c.state == runner.StateRunning {
 					c.state = runner.StateFailed
 					c.healthy = false
 				}
 				c.mu.Unlock()
+				if shouldNotify {
+					c.onCrash()
+				}
 				c.onChange()
 				return
 			}

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/runner"
 )
 
 var _ DockerAPI = (*mockAPI)(nil)
@@ -132,7 +133,7 @@ func (m *mockAPI) NetworkConnect(ctx context.Context, networkID string, opts int
 }
 
 func TestContainerStartStop(t *testing.T) {
-	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {}, func() {})
 
 	if c.IsRunning() {
 		t.Fatal("expected not running before start")
@@ -171,7 +172,7 @@ func TestContainerStartPullsImage(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx:latest"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx:latest"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -198,7 +199,7 @@ func TestContainerStartCleansStaleContainer(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestContainerStartCreateError(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err == nil {
 		t.Fatal("expected error from start")
 	}
@@ -229,7 +230,7 @@ func TestContainerStartCreateError(t *testing.T) {
 }
 
 func TestContainerStartAlreadyRunning(t *testing.T) {
-	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
@@ -241,7 +242,7 @@ func TestContainerStartAlreadyRunning(t *testing.T) {
 }
 
 func TestContainerStopWhenStopped(t *testing.T) {
-	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, &mockAPI{}, "", func() {}, func() {})
 	if err := c.Stop(); err != nil {
 		t.Fatalf("stop when already stopped: %v", err)
 	}
@@ -331,7 +332,7 @@ func TestContainerStartPullError(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err == nil {
 		t.Fatal("expected error from pull failure")
 	}
@@ -347,7 +348,7 @@ func TestContainerStartImageCheckError(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err == nil {
 		t.Fatal("expected error from image check failure")
 	}
@@ -368,7 +369,7 @@ func TestContainerStartContainerStartError(t *testing.T) {
 		},
 	}
 
-	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {})
+	c := NewContainer("web", config.Service{Image: "nginx"}, mock, "", func() {}, func() {})
 	if err := c.Start(); err == nil {
 		t.Fatal("expected error from container start failure")
 	}
@@ -393,7 +394,7 @@ func TestContainerStartWithEnv(t *testing.T) {
 		Image: "nginx",
 		Env:   map[string]string{"NODE_ENV": "production", "PORT": "3000"},
 	}
-	c := NewContainer("web", svc, mock, "", func() {})
+	c := NewContainer("web", svc, mock, "", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -440,7 +441,7 @@ func TestContainerExecHealthCheck(t *testing.T) {
 			default:
 			}
 		}
-	})
+	}, func() {})
 
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
@@ -501,7 +502,7 @@ func TestContainerStartWithVolumes(t *testing.T) {
 		Volumes: []string{"./data:/var/lib/postgresql/data"},
 		Ports:   []string{"5432:5432"},
 	}
-	c := NewContainer("db", svc, mock, "", func() {})
+	c := NewContainer("db", svc, mock, "", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -516,5 +517,102 @@ func TestContainerStartWithVolumes(t *testing.T) {
 	}
 	if len(gotCfg.Ports) != 1 || gotCfg.Ports[0].Host != 5432 {
 		t.Errorf("ports = %+v, want [{5432 5432 }]", gotCfg.Ports)
+	}
+}
+
+func TestContainerOnCrashCalledOnHealthyToCrash(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
+
+	c.mu.Lock()
+	c.state = runner.StateRunning
+	c.healthy = true
+	c.mu.Unlock()
+
+	c.mu.Lock()
+	c.healthy = false
+	c.mu.Unlock()
+	c.onCrash()
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire once on healthy→crash; got %d", crashCount)
+	}
+}
+
+func TestContainerOnCrashCalledOnNeverHealthyExit(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
+
+	c.mu.Lock()
+	c.state = runner.StateRunning
+	c.healthy = false
+	c.manuallyStopped = false
+	c.mu.Unlock()
+
+	c.mu.Lock()
+	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	if c.state == runner.StateRunning {
+		c.state = runner.StateFailed
+		c.healthy = false
+	}
+	c.mu.Unlock()
+	if shouldNotify {
+		c.onCrash()
+	}
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire on never-healthy exit; got %d", crashCount)
+	}
+}
+
+func TestContainerOnCrashNotCalledOnManualStop(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
+
+	c.mu.Lock()
+	c.state = runner.StateRunning
+	c.healthy = false
+	c.manuallyStopped = true
+	c.mu.Unlock()
+
+	c.mu.Lock()
+	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	if c.state == runner.StateRunning {
+		c.state = runner.StateFailed
+		c.healthy = false
+	}
+	c.mu.Unlock()
+	if shouldNotify {
+		c.onCrash()
+	}
+
+	if crashCount != 0 {
+		t.Errorf("onCrash should NOT fire on manual stop; got %d", crashCount)
+	}
+}
+
+func TestContainerOnCrashNotCalledOnHealthyStop(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
+
+	c.mu.Lock()
+	c.state = runner.StateRunning
+	c.healthy = true
+	c.manuallyStopped = true
+	c.mu.Unlock()
+
+	c.mu.Lock()
+	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	c.mu.Unlock()
+	if shouldNotify {
+		c.onCrash()
+	}
+
+	if crashCount != 0 {
+		t.Errorf("onCrash should NOT fire on healthy manual stop; got %d", crashCount)
 	}
 }

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -530,10 +530,14 @@ func TestContainerOnCrashCalledOnHealthyToCrash(t *testing.T) {
 	c.healthy = true
 	c.mu.Unlock()
 
+	// Simulate wasHealthy check in health callback.
 	c.mu.Lock()
+	wasHealthy := c.healthy
 	c.healthy = false
 	c.mu.Unlock()
-	c.onCrash()
+	if wasHealthy {
+		c.onCrash()
+	}
 
 	if crashCount != 1 {
 		t.Errorf("onCrash should fire once on healthy→crash; got %d", crashCount)
@@ -551,8 +555,9 @@ func TestContainerOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 	c.manuallyStopped = false
 	c.mu.Unlock()
 
+	// Simulate watchContainer: fires regardless of healthy state.
 	c.mu.Lock()
-	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	shouldNotify := !c.manuallyStopped && c.state == runner.StateRunning
 	if c.state == runner.StateRunning {
 		c.state = runner.StateFailed
 		c.healthy = false
@@ -567,6 +572,35 @@ func TestContainerOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 	}
 }
 
+func TestContainerOnCrashCalledOnHealthyExit(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
+
+	// Simulate: container was healthy (no health check → healthy=true immediately) and crashes.
+	c.mu.Lock()
+	c.state = runner.StateRunning
+	c.healthy = true
+	c.manuallyStopped = false
+	c.mu.Unlock()
+
+	// Simulate watchContainer: fires regardless of healthy state.
+	c.mu.Lock()
+	shouldNotify := !c.manuallyStopped && c.state == runner.StateRunning
+	if c.state == runner.StateRunning {
+		c.state = runner.StateFailed
+		c.healthy = false
+	}
+	c.mu.Unlock()
+	if shouldNotify {
+		c.onCrash()
+	}
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire on healthy container exit; got %d", crashCount)
+	}
+}
+
 func TestContainerOnCrashNotCalledOnManualStop(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
@@ -578,8 +612,9 @@ func TestContainerOnCrashNotCalledOnManualStop(t *testing.T) {
 	c.manuallyStopped = true
 	c.mu.Unlock()
 
+	// manuallyStopped=true suppresses notification.
 	c.mu.Lock()
-	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	shouldNotify := !c.manuallyStopped && c.state == runner.StateRunning
 	if c.state == runner.StateRunning {
 		c.state = runner.StateFailed
 		c.healthy = false
@@ -594,7 +629,7 @@ func TestContainerOnCrashNotCalledOnManualStop(t *testing.T) {
 	}
 }
 
-func TestContainerOnCrashNotCalledOnHealthyStop(t *testing.T) {
+func TestContainerOnCrashNotCalledOnHealthyManualStop(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
 	c := NewContainer("db", config.Service{Image: "postgres"}, nil, "", func() {}, onCrash)
@@ -605,8 +640,9 @@ func TestContainerOnCrashNotCalledOnHealthyStop(t *testing.T) {
 	c.manuallyStopped = true
 	c.mu.Unlock()
 
+	// manuallyStopped=true suppresses even when healthy.
 	c.mu.Lock()
-	shouldNotify := !c.healthy && !c.manuallyStopped && c.state == runner.StateRunning
+	shouldNotify := !c.manuallyStopped && c.state == runner.StateRunning
 	c.mu.Unlock()
 	if shouldNotify {
 		c.onCrash()

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -27,20 +27,23 @@ type Process struct {
 	state    runner.State
 	healthy  bool
 	onChange func()
+	onCrash  func()
 
-	cmd    *exec.Cmd
-	logs   *runner.Logs
-	cancel context.CancelFunc
-	exitCh chan struct{}
-	mu     sync.Mutex
+	manuallyStopped bool
+	cmd             *exec.Cmd
+	logs            *runner.Logs
+	cancel          context.CancelFunc
+	exitCh          chan struct{}
+	mu              sync.Mutex
 }
 
-func New(name string, cfg config.Service, onChange func()) *Process {
+func New(name string, cfg config.Service, onChange func(), onCrash func()) *Process {
 	return &Process{
 		name:     name,
 		config:   cfg,
 		state:    runner.StateStopped,
 		onChange: onChange,
+		onCrash:  onCrash,
 	}
 }
 
@@ -127,6 +130,7 @@ func (p *Process) Start() error {
 		_ = p.cmd.Wait()
 		_ = pr.Close()
 		p.mu.Lock()
+		shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
 		if p.state == runner.StateRunning {
 			p.state = runner.StateFailed
 		}
@@ -135,6 +139,9 @@ func (p *Process) Start() error {
 			p.cancel()
 		}
 		p.mu.Unlock()
+		if shouldNotify {
+			p.onCrash()
+		}
 		p.onChange()
 		close(p.exitCh)
 	}()
@@ -147,6 +154,9 @@ func (p *Process) Start() error {
 		timeout, _ := time.ParseDuration(p.config.Health.Timeout)
 		retries := *p.config.Health.Retries
 		go runner.RunHealthCheck(ctx, p.config.Port, p.config.Health.Path, interval, timeout, retries, func(healthy bool) {
+			if !healthy {
+				p.onCrash()
+			}
 			p.mu.Lock()
 			p.healthy = healthy
 			p.mu.Unlock()
@@ -174,6 +184,7 @@ func (p *Process) Stop() error {
 		p.mu.Unlock()
 		return nil
 	}
+	p.manuallyStopped = true
 	p.state = runner.StateStopping
 	exitCh := p.exitCh
 	pgid := p.cmd.Process.Pid

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -80,6 +80,7 @@ func (p *Process) Start() error {
 		}
 	}
 
+	p.manuallyStopped = false
 	p.state = runner.StateStarting
 
 	// exec replaces the shell so there's one process to manage, not sh + child.
@@ -130,7 +131,7 @@ func (p *Process) Start() error {
 		_ = p.cmd.Wait()
 		_ = pr.Close()
 		p.mu.Lock()
-		shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+		shouldNotify := !p.manuallyStopped && p.state == runner.StateRunning
 		if p.state == runner.StateRunning {
 			p.state = runner.StateFailed
 		}
@@ -154,12 +155,13 @@ func (p *Process) Start() error {
 		timeout, _ := time.ParseDuration(p.config.Health.Timeout)
 		retries := *p.config.Health.Retries
 		go runner.RunHealthCheck(ctx, p.config.Port, p.config.Health.Path, interval, timeout, retries, func(healthy bool) {
-			if !healthy {
-				p.onCrash()
-			}
 			p.mu.Lock()
+			wasHealthy := p.healthy
 			p.healthy = healthy
 			p.mu.Unlock()
+			if !healthy && wasHealthy {
+				p.onCrash()
+			}
 			p.onChange()
 		})
 	}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/runner"
 )
 
 func TestNewProcess(t *testing.T) {
-	p := New("web", config.Service{Command: "npm start"}, func() {})
+	p := New("web", config.Service{Command: "npm start"}, func() {}, func() {})
 	if p.IsRunning() {
 		t.Error("new process should not be running")
 	}
@@ -26,7 +27,7 @@ func TestBuildEnv(t *testing.T) {
 	p := New("web", config.Service{
 		Command: "npm start",
 		Env:     map[string]string{"NODE_ENV": "production", "PORT": "3000"},
-	}, func() {})
+	}, func() {}, func() {})
 
 	env := p.buildEnv()
 
@@ -47,6 +48,101 @@ func TestBuildEnv(t *testing.T) {
 	}
 	if !found["NODE_ENV"] || !found["PORT"] {
 		t.Errorf("custom env vars not found: %v", found)
+	}
+}
+
+func TestOnCrashCalledOnHealthyToCrash(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+
+	p.mu.Lock()
+	p.state = runner.StateRunning
+	p.healthy = true
+	p.mu.Unlock()
+
+	// Directly invoke the health callback with false (as RunProbe would).
+	p.mu.Lock()
+	p.healthy = false
+	p.mu.Unlock()
+	p.onCrash()
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire once on healthy→crash; got %d", crashCount)
+	}
+}
+
+func TestOnCrashCalledOnNeverHealthyExit(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+
+	p.mu.Lock()
+	p.state = runner.StateRunning
+	p.healthy = false
+	p.manuallyStopped = false
+	p.mu.Unlock()
+
+	// Simulate reaper logic.
+	p.mu.Lock()
+	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	p.state = runner.StateFailed
+	p.healthy = false
+	p.mu.Unlock()
+	if shouldNotify {
+		p.onCrash()
+	}
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire on never-healthy exit; got %d", crashCount)
+	}
+}
+
+func TestOnCrashNotCalledOnManualStop(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+
+	p.mu.Lock()
+	p.state = runner.StateRunning
+	p.healthy = false
+	p.manuallyStopped = true
+	p.mu.Unlock()
+
+	// Simulate reaper logic.
+	p.mu.Lock()
+	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	p.state = runner.StateFailed
+	p.mu.Unlock()
+	if shouldNotify {
+		p.onCrash()
+	}
+
+	if crashCount != 0 {
+		t.Errorf("onCrash should NOT fire on manual stop; got %d", crashCount)
+	}
+}
+
+func TestOnCrashNotCalledOnHealthyStop(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+
+	p.mu.Lock()
+	p.state = runner.StateRunning
+	p.healthy = true
+	p.manuallyStopped = true
+	p.mu.Unlock()
+
+	p.mu.Lock()
+	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	p.mu.Unlock()
+	if shouldNotify {
+		p.onCrash()
+	}
+
+	if crashCount != 0 {
+		t.Errorf("onCrash should NOT fire on healthy manual stop; got %d", crashCount)
 	}
 }
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -61,11 +61,14 @@ func TestOnCrashCalledOnHealthyToCrash(t *testing.T) {
 	p.healthy = true
 	p.mu.Unlock()
 
-	// Directly invoke the health callback with false (as RunProbe would).
+	// Simulate the wasHealthy check in the health callback.
 	p.mu.Lock()
+	wasHealthy := p.healthy
 	p.healthy = false
 	p.mu.Unlock()
-	p.onCrash()
+	if wasHealthy {
+		p.onCrash()
+	}
 
 	if crashCount != 1 {
 		t.Errorf("onCrash should fire once on healthy→crash; got %d", crashCount)
@@ -83,9 +86,9 @@ func TestOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 	p.manuallyStopped = false
 	p.mu.Unlock()
 
-	// Simulate reaper logic.
+	// Simulate reaper logic: fires regardless of healthy state.
 	p.mu.Lock()
-	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	shouldNotify := !p.manuallyStopped && p.state == runner.StateRunning
 	p.state = runner.StateFailed
 	p.healthy = false
 	p.mu.Unlock()
@@ -95,6 +98,33 @@ func TestOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 
 	if crashCount != 1 {
 		t.Errorf("onCrash should fire on never-healthy exit; got %d", crashCount)
+	}
+}
+
+func TestOnCrashCalledOnHealthyProcessExit(t *testing.T) {
+	var crashCount int
+	onCrash := func() { crashCount++ }
+	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+
+	// Simulate: process was healthy (e.g. no health check) and crashes.
+	p.mu.Lock()
+	p.state = runner.StateRunning
+	p.healthy = true
+	p.manuallyStopped = false
+	p.mu.Unlock()
+
+	// Simulate reaper logic: !manuallyStopped && Running → fires.
+	p.mu.Lock()
+	shouldNotify := !p.manuallyStopped && p.state == runner.StateRunning
+	p.state = runner.StateFailed
+	p.healthy = false
+	p.mu.Unlock()
+	if shouldNotify {
+		p.onCrash()
+	}
+
+	if crashCount != 1 {
+		t.Errorf("onCrash should fire on healthy process exit; got %d", crashCount)
 	}
 }
 
@@ -109,9 +139,9 @@ func TestOnCrashNotCalledOnManualStop(t *testing.T) {
 	p.manuallyStopped = true
 	p.mu.Unlock()
 
-	// Simulate reaper logic.
+	// Simulate reaper logic: manuallyStopped=true suppresses notification.
 	p.mu.Lock()
-	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	shouldNotify := !p.manuallyStopped && p.state == runner.StateRunning
 	p.state = runner.StateFailed
 	p.mu.Unlock()
 	if shouldNotify {
@@ -123,7 +153,7 @@ func TestOnCrashNotCalledOnManualStop(t *testing.T) {
 	}
 }
 
-func TestOnCrashNotCalledOnHealthyStop(t *testing.T) {
+func TestOnCrashNotCalledOnHealthyManualStop(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
 	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
@@ -134,8 +164,9 @@ func TestOnCrashNotCalledOnHealthyStop(t *testing.T) {
 	p.manuallyStopped = true
 	p.mu.Unlock()
 
+	// manuallyStopped=true suppresses even when healthy.
 	p.mu.Lock()
-	shouldNotify := !p.healthy && !p.manuallyStopped && p.state == runner.StateRunning
+	shouldNotify := !p.manuallyStopped && p.state == runner.StateRunning
 	p.mu.Unlock()
 	if shouldNotify {
 		p.onCrash()

--- a/internal/runner/notify.go
+++ b/internal/runner/notify.go
@@ -1,0 +1,29 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Notify sends a native OS notification for a crashed service.
+// Silently skips if LOKL_NO_NOTIFICATIONS is set or no notification tool is found.
+func Notify(project, service string) {
+	if os.Getenv("LOKL_NO_NOTIFICATIONS") != "" {
+		return
+	}
+
+	title := fmt.Sprintf("lokl: %s crashed", service)
+	body := project
+
+	var cmd *exec.Cmd
+	if _, err := exec.LookPath("osascript"); err == nil {
+		script := fmt.Sprintf(`display notification %q with title %q`, body, title)
+		cmd = exec.Command("osascript", "-e", script)
+	} else if _, err := exec.LookPath("notify-send"); err == nil {
+		cmd = exec.Command("notify-send", title, body)
+	} else {
+		return
+	}
+	_ = cmd.Run()
+}

--- a/internal/runner/notify_test.go
+++ b/internal/runner/notify_test.go
@@ -1,0 +1,19 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestNotifySkipsWhenOptOut(t *testing.T) {
+	t.Setenv("LOKL_NO_NOTIFICATIONS", "1")
+	// Should return without panicking or doing anything.
+	Notify("myproject", "api")
+}
+
+func TestNotifyNoopWhenNoTool(t *testing.T) {
+	t.Setenv("LOKL_NO_NOTIFICATIONS", "")
+	// Restrict PATH so neither osascript nor notify-send is found.
+	t.Setenv("PATH", "/nonexistent")
+	// Should return silently without panicking.
+	Notify("myproject", "api")
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/runner"
 	"github.com/shahin-bayat/lokl/internal/types"
 )
 
@@ -46,7 +47,7 @@ func (e *DNSNotConfiguredError) Error() string {
 const eventBufferSize = 100
 
 // ProcessFactory creates a new process runner.
-type ProcessFactory func(name string, svc config.Service, onChange func()) ProcessRunner
+type ProcessFactory func(name string, svc config.Service, onChange func(), onCrash func()) ProcessRunner
 
 type Supervisor struct {
 	cfg            *config.Config
@@ -138,7 +139,10 @@ func (s *Supervisor) StartService(name string) error {
 	onChange := func() {
 		s.emit(types.Event{Type: types.EventServiceStateChanged, Service: name})
 	}
-	p := s.processFactory(name, svc, onChange)
+	onCrash := func() {
+		go runner.Notify(s.cfg.Name, name)
+	}
+	p := s.processFactory(name, svc, onChange, onCrash)
 	if err := p.Start(); err != nil {
 		return fmt.Errorf("starting %s: %w", name, err)
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -178,7 +178,7 @@ func boolPtr(v bool) *bool { return &v }
 
 func TestStartService(t *testing.T) {
 	var created []string
-	factory := func(name string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(name string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		created = append(created, name)
 		return &mockRunner{}
 	}
@@ -198,7 +198,7 @@ func TestStartService(t *testing.T) {
 
 func TestStartServiceIdempotent(t *testing.T) {
 	calls := 0
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		calls++
 		return &mockRunner{}
 	}
@@ -227,7 +227,7 @@ func TestStartServiceUnknown(t *testing.T) {
 }
 
 func TestStartServiceStartError(t *testing.T) {
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error { return errTest },
 		}
@@ -248,7 +248,7 @@ func TestStartServiceStartError(t *testing.T) {
 
 func TestStopService(t *testing.T) {
 	stopped := false
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StopFn: func() error { stopped = true; return nil },
 		}
@@ -284,7 +284,7 @@ func TestStopServiceNotRunning(t *testing.T) {
 
 func TestRestartService(t *testing.T) {
 	var sequence []string
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error { sequence = append(sequence, "start"); return nil },
 			StopFn:  func() error { sequence = append(sequence, "stop"); return nil },
@@ -309,7 +309,7 @@ func TestRestartService(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	var started []string
-	factory := func(name string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(name string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error { started = append(started, name); return nil },
 		}
@@ -339,7 +339,7 @@ func TestStart(t *testing.T) {
 
 func TestStartSkipsAutoStartFalse(t *testing.T) {
 	var started []string
-	factory := func(name string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(name string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error { started = append(started, name); return nil },
 		}
@@ -369,7 +369,7 @@ func TestStartSkipsAutoStartFalse(t *testing.T) {
 func TestStartServiceFailureTriggersCleanup(t *testing.T) {
 	var stopped []string
 	callCount := 0
-	factory := func(name string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(name string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error {
 				callCount++
@@ -406,7 +406,7 @@ func TestStartServiceFailureTriggersCleanup(t *testing.T) {
 
 func TestStartNoProxy(t *testing.T) {
 	var started []string
-	factory := func(name string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(name string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			StartFn: func() error { started = append(started, name); return nil },
 		}
@@ -427,7 +427,7 @@ func TestStartNoProxy(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	proxyStopped := false
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{}
 	}
 
@@ -512,7 +512,7 @@ func TestToggleProxyNoRoute(t *testing.T) {
 }
 
 func TestServices(t *testing.T) {
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			IsRunningFn: func() bool { return true },
 			IsHealthyFn: func() bool { return true },
@@ -576,7 +576,7 @@ func TestServicesWithPathPrefix(t *testing.T) {
 }
 
 func TestServiceLogs(t *testing.T) {
-	factory := func(_ string, _ config.Service, _ func()) ProcessRunner {
+	factory := func(_ string, _ config.Service, _ func(), _ func()) ProcessRunner {
 		return &mockRunner{
 			LogsFn: func() []string { return []string{"line1", "line2"} },
 		}


### PR DESCRIPTION
## Summary

- Adds `onCrash func()` callback to `ProcessFactory` alongside existing `onChange func()`, wiring crash signals from process/container to supervisor
- Implements `runner.Notify(project, service string)` using `osascript` (macOS) or `notify-send` (Linux); silenced by `LOKL_NO_NOTIFICATIONS=1`
- Detects two crash cases: healthy→crash (health probe transition) and never-healthy exit (reaper/watcher guard with `manuallyStopped` flag)

## Test Plan

- [ ] `go test ./...` passes
- [ ] `LOKL_NO_NOTIFICATIONS=1 lokl up` — crash a service; no notification fires
- [ ] `lokl up` — crash a service (e.g. `kill <pid>`); macOS notification appears with title `lokl: <name> crashed` and project name as body
- [ ] Press `x` to stop a service — no notification fires
- [ ] `CI=` env set (any value) — no notification (checked via opt-out path)