### PR TITLE
feat: container command override, anonymous volumes, process exec-form

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ services:
     image: redis:7
 ```
 
+### Override a container's command
+
+```yaml
+services:
+  web:
+    image: node:20
+    command: "npm run dev"  # overrides image CMD, keeps ENTRYPOINT
+```
+
 Then:
 - `https://app.myproject.dev` → frontend (port 5173)
 - `https://api.myproject.dev` → api (port 3000)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 		s.Shell = false
 		return value.Decode(&s.Args)
 	default:
-		return fmt.Errorf("command: expected string or sequence, got %v", value.Tag)
+		return fmt.Errorf("expected string or sequence, got %v", value.Tag)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,9 +24,9 @@ type ProxyConfig struct {
 }
 
 type Service struct {
-	Command string `yaml:"command"`
-	Image   string `yaml:"image"`
-	Path    string `yaml:"path"`
+	Command StringOrSlice `yaml:"command"`
+	Image   string        `yaml:"image"`
+	Path    string        `yaml:"path"`
 
 	Port      int    `yaml:"port"`
 	Subdomain string `yaml:"subdomain"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 		s.Shell = false
 		return value.Decode(&s.Args)
 	default:
-		return fmt.Errorf("health.command: expected string or sequence, got %v", value.Tag)
+		return fmt.Errorf("command: expected string or sequence, got %v", value.Tag)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,7 +78,7 @@ func TestValidate(t *testing.T) {
 	}{
 		{
 			name:    "missing name",
-			cfg:     Config{Services: map[string]Service{"a": {Command: "x"}}},
+			cfg:     Config{Services: map[string]Service{"a": {Command: cmdStr("x")}}},
 			wantErr: "name is required",
 		},
 		{
@@ -95,18 +95,15 @@ func TestValidate(t *testing.T) {
 			wantErr: "command or image is required",
 		},
 		{
-			name: "both command and image",
-			cfg: Config{
-				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", Image: "y"}},
-			},
-			wantErr: "cannot specify both command and image",
+			name:    "command overrides image command",
+			cfg:     Config{Name: "test", Services: map[string]Service{"a": {Command: cmdStr("npm run dev"), Image: "node:20"}}},
+			wantErr: "",
 		},
 		{
 			name: "subdomain without proxy domain",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", Subdomain: "app", Port: 3000}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomain: "app", Port: 3000}},
 			},
 			wantErr: "has subdomain but proxy.domain is not configured",
 		},
@@ -115,7 +112,7 @@ func TestValidate(t *testing.T) {
 			cfg: Config{
 				Name:     "test",
 				Proxy:    ProxyConfig{Domain: "test.dev"},
-				Services: map[string]Service{"a": {Command: "x", Subdomain: "app"}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomain: "app"}},
 			},
 			wantErr: "port is required when subdomain is set",
 		},
@@ -123,7 +120,7 @@ func TestValidate(t *testing.T) {
 			name: "unknown dependency",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", DependsOn: []string{"unknown"}}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), DependsOn: []string{"unknown"}}},
 			},
 			wantErr: "depends_on references unknown service",
 		},
@@ -131,7 +128,7 @@ func TestValidate(t *testing.T) {
 			name: "invalid ready_timeout",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", ReadyTimeout: "bad"}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), ReadyTimeout: "bad"}},
 			},
 			wantErr: "invalid ready_timeout",
 		},
@@ -139,7 +136,7 @@ func TestValidate(t *testing.T) {
 			name: "invalid restart policy",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", Restart: "bad"}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Restart: "bad"}},
 			},
 			wantErr: "invalid restart policy",
 		},
@@ -147,7 +144,7 @@ func TestValidate(t *testing.T) {
 			name: "invalid health interval",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x", Health: &HealthConfig{Interval: "bad"}}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Health: &HealthConfig{Interval: "bad"}}},
 			},
 			wantErr: "invalid health.interval",
 		},
@@ -156,8 +153,8 @@ func TestValidate(t *testing.T) {
 			cfg: Config{
 				Name: "test",
 				Services: map[string]Service{
-					"a": {Command: "x", Port: 3000},
-					"b": {Command: "y", Port: 3000},
+					"a": {Command: cmdStr("x"), Port: 3000},
+					"b": {Command: cmdStr("y"), Port: 3000},
 				},
 			},
 			wantErr: "both use port 3000",
@@ -207,7 +204,7 @@ func TestValidate(t *testing.T) {
 			cfg: Config{
 				Name: "test",
 				Services: map[string]Service{
-					"a": {Command: "x", Port: 8080},
+					"a": {Command: cmdStr("x"), Port: 8080},
 					"b": {Image: "nginx", Ports: []string{"8080:80"}},
 				},
 			},
@@ -227,8 +224,8 @@ func TestValidate(t *testing.T) {
 				Name:  "test",
 				Proxy: ProxyConfig{Domain: "test.dev"},
 				Services: map[string]Service{
-					"a": {Command: "x", Subdomain: "client", Port: 8080},
-					"b": {Command: "y", Subdomain: "client", Port: 8081},
+					"a": {Command: cmdStr("x"), Subdomain: "client", Port: 8080},
+					"b": {Command: cmdStr("y"), Subdomain: "client", Port: 8081},
 				},
 			},
 			wantErr: "same subdomain with no prefix",
@@ -239,8 +236,8 @@ func TestValidate(t *testing.T) {
 				Name:  "test",
 				Proxy: ProxyConfig{Domain: "test.dev"},
 				Services: map[string]Service{
-					"a": {Command: "x", Subdomain: "client", Port: 8080, Rewrite: &RewriteConfig{StripPrefix: "app-a"}},
-					"b": {Command: "y", Subdomain: "client", Port: 8081, Rewrite: &RewriteConfig{StripPrefix: "app-b"}},
+					"a": {Command: cmdStr("x"), Subdomain: "client", Port: 8080, Rewrite: &RewriteConfig{StripPrefix: "app-a"}},
+					"b": {Command: cmdStr("y"), Subdomain: "client", Port: 8081, Rewrite: &RewriteConfig{StripPrefix: "app-b"}},
 				},
 			},
 			wantErr: "",
@@ -249,7 +246,7 @@ func TestValidate(t *testing.T) {
 			name: "valid config",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: "x"}},
+				Services: map[string]Service{"a": {Command: cmdStr("x")}},
 			},
 			wantErr: "",
 		},
@@ -306,8 +303,8 @@ func TestLoadWithEnvFile(t *testing.T) {
 func TestApplyDefaults(t *testing.T) {
 	cfg := &Config{
 		Services: map[string]Service{
-			"a": {Command: "x"},
-			"b": {Command: "y", Health: &HealthConfig{Path: "/health"}},
+			"a": {Command: cmdStr("x")},
+			"b": {Command: cmdStr("y"), Health: &HealthConfig{Path: "/health"}},
 		},
 	}
 
@@ -466,5 +463,31 @@ services:
 	}
 	if !strings.Contains(err.Error(), "path") || !strings.Contains(err.Error(), "command") {
 		t.Errorf("error should mention both path and command, got: %v", err)
+	}
+}
+
+func TestServiceCommandParsing(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantArgs  []string
+		wantShell bool
+	}{
+		{"scalar", `command: "npm run dev"`, []string{"npm run dev"}, true},
+		{"sequence", `command: ["npm","run","dev"]`, []string{"npm", "run", "dev"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s Service
+			if err := yaml.Unmarshal([]byte(tt.yaml), &s); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !slices.Equal(s.Command.Args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", s.Command.Args, tt.wantArgs)
+			}
+			if s.Command.Shell != tt.wantShell {
+				t.Errorf("shell = %v, want %v", s.Command.Shell, tt.wantShell)
+			}
+		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -191,7 +191,15 @@ func TestValidate(t *testing.T) {
 				Name:     "test",
 				Services: map[string]Service{"a": {Image: "nginx", Volumes: []string{"bad"}}},
 			},
-			wantErr: "invalid volume",
+			wantErr: "container path must be absolute",
+		},
+		{
+			name: "docker: anonymous volume accepted",
+			cfg: Config{
+				Name:     "test",
+				Services: map[string]Service{"a": {Image: "nginx", Volumes: []string{"/var/www/html/vendor"}}},
+			},
+			wantErr: "",
 		},
 		{
 			name: "docker: volume relative container path",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,11 @@ func TestValidate(t *testing.T) {
 			wantErr: "command must not be empty",
 		},
 		{
+			name:    "path not allowed with image",
+			cfg:     Config{Name: "test", Services: map[string]Service{"a": {Image: "node:20", Path: "./frontend"}}},
+			wantErr: "path is only valid for command-based services",
+		},
+		{
 			name: "subdomain without proxy domain",
 			cfg: Config{
 				Name:     "test",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,16 @@ func TestValidate(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name:    "empty command string",
+			cfg:     Config{Name: "test", Services: map[string]Service{"a": {Command: cmdStr("")}}},
+			wantErr: "command must not be empty",
+		},
+		{
+			name:    "empty command list",
+			cfg:     Config{Name: "test", Services: map[string]Service{"a": {Command: cmdArgs("")}}},
+			wantErr: "command must not be empty",
+		},
+		{
 			name: "subdomain without proxy domain",
 			cfg: Config{
 				Name:     "test",

--- a/internal/config/deps_test.go
+++ b/internal/config/deps_test.go
@@ -15,8 +15,8 @@ func TestSortByDependency(t *testing.T) {
 		{
 			name: "no dependencies",
 			services: map[string]Service{
-				"a": {Command: "x"},
-				"b": {Command: "x"},
+				"a": {Command: cmdStr("x")},
+				"b": {Command: cmdStr("x")},
 			},
 			validate: func(order []string) bool {
 				return len(order) == 2
@@ -25,8 +25,8 @@ func TestSortByDependency(t *testing.T) {
 		{
 			name: "linear chain",
 			services: map[string]Service{
-				"api": {Command: "x", DependsOn: []string{"db"}},
-				"db":  {Command: "x"},
+				"api": {Command: cmdStr("x"), DependsOn: []string{"db"}},
+				"db":  {Command: cmdStr("x")},
 			},
 			validate: func(order []string) bool {
 				return indexOf(order, "db") < indexOf(order, "api")
@@ -35,9 +35,9 @@ func TestSortByDependency(t *testing.T) {
 		{
 			name: "multiple dependencies",
 			services: map[string]Service{
-				"api":   {Command: "x", DependsOn: []string{"db", "redis"}},
-				"db":    {Command: "x"},
-				"redis": {Command: "x"},
+				"api":   {Command: cmdStr("x"), DependsOn: []string{"db", "redis"}},
+				"db":    {Command: cmdStr("x")},
+				"redis": {Command: cmdStr("x")},
 			},
 			validate: func(order []string) bool {
 				apiIdx := indexOf(order, "api")
@@ -47,15 +47,15 @@ func TestSortByDependency(t *testing.T) {
 		{
 			name: "circular dependency",
 			services: map[string]Service{
-				"a": {Command: "x", DependsOn: []string{"b"}},
-				"b": {Command: "x", DependsOn: []string{"a"}},
+				"a": {Command: cmdStr("x"), DependsOn: []string{"b"}},
+				"b": {Command: cmdStr("x"), DependsOn: []string{"a"}},
 			},
 			wantErr: "circular dependency",
 		},
 		{
 			name: "unknown dependency",
 			services: map[string]Service{
-				"a": {Command: "x", DependsOn: []string{"unknown"}},
+				"a": {Command: cmdStr("x"), DependsOn: []string{"unknown"}},
 			},
 			wantErr: "unknown service",
 		},

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -81,7 +81,7 @@ func TestResolveEnv(t *testing.T) {
 			Name: "test",
 			Env:  map[string]string{"URL": "http://${TEST_HOST}:8080"},
 			Services: map[string]Service{
-				"api": {Command: "x", Env: map[string]string{"DSN": "postgres://$TEST_HOST/db"}},
+				"api": {Command: cmdStr("x"), Env: map[string]string{"DSN": "postgres://$TEST_HOST/db"}},
 			},
 		}
 
@@ -133,7 +133,7 @@ func TestResolveEnv(t *testing.T) {
 			Env:     map[string]string{"DB_USER": "admin"},
 			Services: map[string]Service{
 				"api": {
-					Command: "x",
+					Command: cmdStr("x"),
 					EnvFile: []string{"testdata/test.env"},
 					Env:     map[string]string{"DB_PASS": "override"},
 				},
@@ -157,7 +157,7 @@ func TestResolveEnv(t *testing.T) {
 			EnvFile: []string{"testdata/test.env"},
 			Services: map[string]Service{
 				"api": {
-					Command: "x",
+					Command: cmdStr("x"),
 					Env:     map[string]string{"DSN": "postgres://${DB_USER}:${DB_PASS}@localhost/db"},
 				},
 			},

--- a/internal/config/testhelpers_test.go
+++ b/internal/config/testhelpers_test.go
@@ -1,0 +1,9 @@
+package config
+
+func cmdStr(s string) StringOrSlice {
+	return StringOrSlice{Args: []string{s}, Shell: true}
+}
+
+func cmdArgs(args ...string) StringOrSlice {
+	return StringOrSlice{Args: args, Shell: false}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -78,6 +78,10 @@ func validateService(name string, svc *Service, services map[string]Service) err
 		return fmt.Errorf("service %q: command or image is required", name)
 	}
 
+	if hasCommand && strings.TrimSpace(svc.Command.Args[0]) == "" {
+		return fmt.Errorf("service %q: command must not be empty", name)
+	}
+
 	if svc.Subdomain != "" && svc.Port == 0 {
 		return fmt.Errorf("service %q: port is required when subdomain is set", name)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -82,6 +82,10 @@ func validateService(name string, svc *Service, services map[string]Service) err
 		return fmt.Errorf("service %q: command must not be empty", name)
 	}
 
+	if hasImage && svc.Path != "" {
+		return fmt.Errorf("service %q: path is only valid for command-based services; container services cannot set path", name)
+	}
+
 	if svc.Subdomain != "" && svc.Port == 0 {
 		return fmt.Errorf("service %q: port is required when subdomain is set", name)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -71,14 +71,11 @@ func checkDuplicatePorts(services map[string]Service) error {
 }
 
 func validateService(name string, svc *Service, services map[string]Service) error {
-	hasCommand := svc.Command != ""
+	hasCommand := svc.Command.IsSet()
 	hasImage := svc.Image != ""
 
 	if !hasCommand && !hasImage {
 		return fmt.Errorf("service %q: command or image is required", name)
-	}
-	if hasCommand && hasImage {
-		return fmt.Errorf("service %q: cannot specify both command and image", name)
 	}
 
 	if svc.Subdomain != "" && svc.Port == 0 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -157,8 +157,14 @@ func validateDockerService(name string, svc *Service) error {
 	}
 
 	for _, raw := range svc.Volumes {
+		if !strings.Contains(raw, ":") {
+			if !strings.HasPrefix(raw, "/") {
+				return fmt.Errorf("service %q: invalid volume %q: container path must be absolute", name, raw)
+			}
+			continue
+		}
 		parts := strings.SplitN(raw, ":", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		if parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("service %q: invalid volume %q: expected host:container format", name, raw)
 		}
 		if !strings.HasPrefix(parts[1], "/") {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -135,6 +135,7 @@ func (c *Client) CreateContainer(ctx context.Context, cfg ContainerConfig) (stri
 		Name: cfg.Name,
 		Config: &container.Config{
 			Image:        cfg.Image,
+			Cmd:          cfg.Cmd,
 			Env:          env,
 			Labels:       labels,
 			ExposedPorts: exposedPorts,

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -131,6 +131,14 @@ func (c *Client) CreateContainer(ctx context.Context, cfg ContainerConfig) (stri
 		}
 	}
 
+	var anonVolumes map[string]struct{}
+	if len(cfg.AnonymousVolumes) > 0 {
+		anonVolumes = make(map[string]struct{}, len(cfg.AnonymousVolumes))
+		for _, p := range cfg.AnonymousVolumes {
+			anonVolumes[p] = struct{}{}
+		}
+	}
+
 	resp, err := c.api.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name: cfg.Name,
 		Config: &container.Config{
@@ -139,6 +147,7 @@ func (c *Client) CreateContainer(ctx context.Context, cfg ContainerConfig) (stri
 			Env:          env,
 			Labels:       labels,
 			ExposedPorts: exposedPorts,
+			Volumes:      anonVolumes,
 		},
 		HostConfig: &container.HostConfig{
 			Binds:        cfg.Volumes,

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -131,14 +131,6 @@ func (c *Client) CreateContainer(ctx context.Context, cfg ContainerConfig) (stri
 		}
 	}
 
-	var anonVolumes map[string]struct{}
-	if len(cfg.AnonymousVolumes) > 0 {
-		anonVolumes = make(map[string]struct{}, len(cfg.AnonymousVolumes))
-		for _, p := range cfg.AnonymousVolumes {
-			anonVolumes[p] = struct{}{}
-		}
-	}
-
 	resp, err := c.api.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name: cfg.Name,
 		Config: &container.Config{
@@ -147,7 +139,6 @@ func (c *Client) CreateContainer(ctx context.Context, cfg ContainerConfig) (stri
 			Env:          env,
 			Labels:       labels,
 			ExposedPorts: exposedPorts,
-			Volumes:      anonVolumes,
 		},
 		HostConfig: &container.HostConfig{
 			Binds:        cfg.Volumes,

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -100,10 +100,16 @@ func (c *Container) Start() error {
 		}
 	}
 
-	volumes, anonVolumes, err := splitVolumes(c.config.Volumes)
+	volumes, anonPaths, err := splitVolumes(c.config.Volumes)
 	if err != nil {
 		c.setFailed()
 		return fmt.Errorf("container %s: %w", c.name, err)
+	}
+	// Convert bare container paths into deterministically-named volumes so
+	// masked directories (vendor/, node_modules/) survive container recreation.
+	// Anonymous volumes would be deleted by RemoveContainer(RemoveVolumes=true).
+	for _, p := range anonPaths {
+		volumes = append(volumes, namedMaskVolume(c.name, p)+":"+p)
 	}
 
 	ports, err := parsePorts(c.config.Ports)
@@ -120,15 +126,14 @@ func (c *Container) Start() error {
 	}
 
 	cfg := ContainerConfig{
-		Name:             containerName,
-		Image:            c.config.Image,
-		Env:              c.config.Env,
-		Ports:            ports,
-		Volumes:          volumes,
-		AnonymousVolumes: anonVolumes,
-		Labels:           map[string]string{containerLabel: c.name},
-		Network:          c.network,
-		NetworkAliases:   []string{c.name},
+		Name:           containerName,
+		Image:          c.config.Image,
+		Env:            c.config.Env,
+		Ports:          ports,
+		Volumes:        volumes,
+		Labels:         map[string]string{containerLabel: c.name},
+		Network:        c.network,
+		NetworkAliases: []string{c.name},
 	}
 	if c.config.Command.IsSet() {
 		cfg.Cmd = buildExecCmd(c.config.Command)
@@ -305,6 +310,15 @@ func parseHealthParams(h *config.HealthConfig) (interval, timeout time.Duration,
 		retries = *h.Retries
 	}
 	return
+}
+
+// namedMaskVolume returns a deterministic Docker volume name for a masked
+// container path. Using a named volume (rather than an anonymous one) keeps
+// dependencies like vendor/ or node_modules/ around across container
+// recreation. Docker volume names must match [a-zA-Z0-9][a-zA-Z0-9_.-]+.
+func namedMaskVolume(serviceName, containerPath string) string {
+	safe := strings.Trim(strings.ReplaceAll(containerPath, "/", "-"), "-")
+	return fmt.Sprintf("lokl-mask-%s-%s", serviceName, safe)
 }
 
 func buildExecCmd(s config.StringOrSlice) []string {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -129,6 +129,9 @@ func (c *Container) Start() error {
 		Network:        c.network,
 		NetworkAliases: []string{c.name},
 	}
+	if c.config.Command.IsSet() {
+		cfg.Cmd = buildExecCmd(c.config.Command)
+	}
 
 	id, err := c.api.CreateContainer(ctx, cfg)
 	if err != nil {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -109,7 +109,7 @@ func (c *Container) Start() error {
 	// masked directories (vendor/, node_modules/) survive container recreation.
 	// Anonymous volumes would be deleted by RemoveContainer(RemoveVolumes=true).
 	for _, p := range anonPaths {
-		volumes = append(volumes, namedMaskVolume(c.name, p)+":"+p)
+		volumes = append(volumes, namedMaskVolume(c.network, c.name, p)+":"+p)
 	}
 
 	ports, err := parsePorts(c.config.Ports)
@@ -315,10 +315,33 @@ func parseHealthParams(h *config.HealthConfig) (interval, timeout time.Duration,
 // namedMaskVolume returns a deterministic Docker volume name for a masked
 // container path. Using a named volume (rather than an anonymous one) keeps
 // dependencies like vendor/ or node_modules/ around across container
-// recreation. Docker volume names must match [a-zA-Z0-9][a-zA-Z0-9_.-]+.
-func namedMaskVolume(serviceName, containerPath string) string {
-	safe := strings.Trim(strings.ReplaceAll(containerPath, "/", "-"), "-")
-	return fmt.Sprintf("lokl-mask-%s-%s", serviceName, safe)
+// recreation. The project-scoped network name is baked into the prefix so
+// two projects with identically named services don't collide on the global
+// Docker volume namespace. Docker volume names must match
+// [a-zA-Z0-9][a-zA-Z0-9_.-]+, so any other character is replaced with '-'.
+func namedMaskVolume(network, serviceName, containerPath string) string {
+	prefix := "lokl-mask"
+	if network != "" {
+		prefix = network + "-mask"
+	}
+	return fmt.Sprintf("%s-%s-%s", prefix, sanitizeVolumeName(serviceName), sanitizeVolumeName(containerPath))
+}
+
+func sanitizeVolumeName(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '_', r == '.', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+	for strings.Contains(mapped, "--") {
+		mapped = strings.ReplaceAll(mapped, "--", "-")
+	}
+	return strings.Trim(mapped, "-")
 }
 
 func buildExecCmd(s config.StringOrSlice) []string {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -100,7 +100,7 @@ func (c *Container) Start() error {
 		}
 	}
 
-	volumes, err := absVolumes(c.config.Volumes)
+	volumes, anonVolumes, err := splitVolumes(c.config.Volumes)
 	if err != nil {
 		c.setFailed()
 		return fmt.Errorf("container %s: %w", c.name, err)
@@ -120,14 +120,15 @@ func (c *Container) Start() error {
 	}
 
 	cfg := ContainerConfig{
-		Name:           containerName,
-		Image:          c.config.Image,
-		Env:            c.config.Env,
-		Ports:          ports,
-		Volumes:        volumes,
-		Labels:         map[string]string{containerLabel: c.name},
-		Network:        c.network,
-		NetworkAliases: []string{c.name},
+		Name:             containerName,
+		Image:            c.config.Image,
+		Env:              c.config.Env,
+		Ports:            ports,
+		Volumes:          volumes,
+		AnonymousVolumes: anonVolumes,
+		Labels:           map[string]string{containerLabel: c.name},
+		Network:          c.network,
+		NetworkAliases:   []string{c.name},
 	}
 	if c.config.Command.IsSet() {
 		cfg.Cmd = buildExecCmd(c.config.Command)
@@ -330,33 +331,37 @@ func expandHealthCmd(s config.StringOrSlice, env map[string]string) config.Strin
 	return config.StringOrSlice{Args: expanded, Shell: s.Shell}
 }
 
-// absVolumes resolves relative host paths in volume mappings to absolute paths
-// and pre-creates the host directory if it doesn't exist.
-// Docker requires absolute host paths; Docker Desktop won't auto-create missing dirs.
+// splitVolumes separates bind/named mounts from anonymous volumes (bare container paths).
+// Bind mount host paths are resolved to absolute and the directory is pre-created (Docker
+// requires absolute host paths; Docker Desktop won't auto-create missing dirs).
 // Named volumes (e.g. "pgdata:/var/lib/...") are passed through unchanged.
-func absVolumes(raw []string) ([]string, error) {
-	out := make([]string, len(raw))
-	for i, v := range raw {
+// Anonymous volumes ("/container/path") let Docker create an unnamed volume that masks
+// a directory from an outer bind mount (e.g. vendor/ on top of a source bind).
+func splitVolumes(raw []string) (binds []string, anon []string, err error) {
+	binds = make([]string, 0, len(raw))
+	for _, v := range raw {
 		host, rest, ok := strings.Cut(v, ":")
-		if ok && (strings.HasPrefix(host, "/") || strings.HasPrefix(host, ".")) {
-			// Bind mount: resolve to absolute and pre-create directory if needed.
+		if !ok {
+			anon = append(anon, v)
+			continue
+		}
+		if strings.HasPrefix(host, "/") || strings.HasPrefix(host, ".") {
 			if !filepath.IsAbs(host) {
-				if abs, err := filepath.Abs(host); err == nil {
+				if abs, absErr := filepath.Abs(host); absErr == nil {
 					host = abs
 				}
 			}
-			// Skip MkdirAll if the path already exists as a file (file bind-mount).
 			if info, statErr := os.Lstat(host); os.IsNotExist(statErr) || (statErr == nil && info.IsDir()) {
-				if err := os.MkdirAll(host, 0o755); err != nil {
-					return nil, fmt.Errorf("creating volume directory %q: %w", host, err)
+				if mkErr := os.MkdirAll(host, 0o755); mkErr != nil {
+					return nil, nil, fmt.Errorf("creating volume directory %q: %w", host, mkErr)
 				}
 			}
-			out[i] = host + ":" + rest
-		} else {
-			out[i] = v
+			binds = append(binds, host+":"+rest)
+			continue
 		}
+		binds = append(binds, v)
 	}
-	return out, nil
+	return binds, anon, nil
 }
 
 func parsePorts(raw []string) ([]PortMapping, error) {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -309,9 +309,10 @@ func parseHealthParams(h *config.HealthConfig) (interval, timeout time.Duration,
 
 func buildExecCmd(s config.StringOrSlice) []string {
 	if s.Shell {
-		// `exec` replaces the shell so the real process becomes PID 1 and
-		// receives signals directly (otherwise `sh` swallows SIGTERM).
-		return []string{"sh", "-c", "exec " + strings.Join(s.Args, " ")}
+		// No `exec` wrapping here: it would break compound expressions like
+		// `a && b` or `a || exit 1` (used by health.command). Callers that
+		// want the app as PID 1 for signal handling should use the list form.
+		return []string{"sh", "-c", strings.Join(s.Args, " ")}
 	}
 	return s.Args
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -309,7 +309,9 @@ func parseHealthParams(h *config.HealthConfig) (interval, timeout time.Duration,
 
 func buildExecCmd(s config.StringOrSlice) []string {
 	if s.Shell {
-		return []string{"sh", "-c", strings.Join(s.Args, " ")}
+		// `exec` replaces the shell so the real process becomes PID 1 and
+		// receives signals directly (otherwise `sh` swallows SIGTERM).
+		return []string{"sh", "-c", "exec " + strings.Join(s.Args, " ")}
 	}
 	return s.Args
 }

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -722,3 +722,35 @@ func TestContainerCommandOverride_Unset(t *testing.T) {
 		t.Errorf("Cmd = %v, want nil (image default)", gotCfg.Cmd)
 	}
 }
+
+func TestContainerAnonymousVolumes(t *testing.T) {
+	var gotCfg ContainerConfig
+	mock := &mockAPI{
+		CreateContainerFn: func(_ context.Context, cfg ContainerConfig) (string, error) {
+			gotCfg = cfg
+			return "test-id", nil
+		},
+	}
+
+	svc := config.Service{
+		Image: "node:20",
+		Volumes: []string{
+			"./app:/var/www/html",
+			"/var/www/html/vendor",
+			"/var/www/html/node_modules",
+		},
+	}
+	c := NewContainer("web", svc, mock, "", func() {}, func() {})
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	if len(gotCfg.Volumes) != 1 {
+		t.Errorf("binds count = %d, want 1", len(gotCfg.Volumes))
+	}
+	wantAnon := []string{"/var/www/html/vendor", "/var/www/html/node_modules"}
+	if !slices.Equal(gotCfg.AnonymousVolumes, wantAnon) {
+		t.Errorf("AnonymousVolumes = %v, want %v", gotCfg.AnonymousVolumes, wantAnon)
+	}
+}

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -723,7 +723,7 @@ func TestContainerCommandOverride_Unset(t *testing.T) {
 	}
 }
 
-func TestContainerAnonymousVolumes(t *testing.T) {
+func TestContainerMaskVolumes(t *testing.T) {
 	var gotCfg ContainerConfig
 	mock := &mockAPI{
 		CreateContainerFn: func(_ context.Context, cfg ContainerConfig) (string, error) {
@@ -746,11 +746,17 @@ func TestContainerAnonymousVolumes(t *testing.T) {
 	}
 	defer func() { _ = c.Stop() }()
 
-	if len(gotCfg.Volumes) != 1 {
-		t.Errorf("binds count = %d, want 1", len(gotCfg.Volumes))
+	// Expect 3 binds: 1 host-mapped + 2 named mask volumes.
+	if len(gotCfg.Volumes) != 3 {
+		t.Fatalf("binds count = %d, want 3 (%v)", len(gotCfg.Volumes), gotCfg.Volumes)
 	}
-	wantAnon := []string{"/var/www/html/vendor", "/var/www/html/node_modules"}
-	if !slices.Equal(gotCfg.AnonymousVolumes, wantAnon) {
-		t.Errorf("AnonymousVolumes = %v, want %v", gotCfg.AnonymousVolumes, wantAnon)
+	wantMask := []string{
+		"lokl-mask-web-var-www-html-vendor:/var/www/html/vendor",
+		"lokl-mask-web-var-www-html-node_modules:/var/www/html/node_modules",
+	}
+	for _, w := range wantMask {
+		if !slices.Contains(gotCfg.Volumes, w) {
+			t.Errorf("missing mask bind %q; got %v", w, gotCfg.Volumes)
+		}
 	}
 }

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -740,23 +740,37 @@ func TestContainerMaskVolumes(t *testing.T) {
 			"/var/www/html/node_modules",
 		},
 	}
-	c := NewContainer("web", svc, mock, "", func() {}, func() {})
+	c := NewContainer("web", svc, mock, "lokl-demo", func() {}, func() {})
 	if err := c.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 	defer func() { _ = c.Stop() }()
 
-	// Expect 3 binds: 1 host-mapped + 2 named mask volumes.
+	// Expect 3 binds: 1 host-mapped + 2 project-scoped named mask volumes.
 	if len(gotCfg.Volumes) != 3 {
 		t.Fatalf("binds count = %d, want 3 (%v)", len(gotCfg.Volumes), gotCfg.Volumes)
 	}
 	wantMask := []string{
-		"lokl-mask-web-var-www-html-vendor:/var/www/html/vendor",
-		"lokl-mask-web-var-www-html-node_modules:/var/www/html/node_modules",
+		"lokl-demo-mask-web-var-www-html-vendor:/var/www/html/vendor",
+		"lokl-demo-mask-web-var-www-html-node_modules:/var/www/html/node_modules",
 	}
 	for _, w := range wantMask {
 		if !slices.Contains(gotCfg.Volumes, w) {
 			t.Errorf("missing mask bind %q; got %v", w, gotCfg.Volumes)
 		}
+	}
+}
+
+func TestNamedMaskVolumeSanitize(t *testing.T) {
+	got := namedMaskVolume("lokl-demo", "web", "/app/node_modules/@types")
+	want := "lokl-demo-mask-web-app-node_modules-types"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// Empty network → no project prefix
+	got = namedMaskVolume("", "web", "/data")
+	want = "lokl-mask-web-data"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -470,7 +470,7 @@ func TestBuildExecCmd(t *testing.T) {
 		{
 			name:  "string form — sh -c wrap",
 			input: config.StringOrSlice{Args: []string{"pg_isready", "-U", "postgres"}, Shell: true},
-			want:  []string{"sh", "-c", "exec pg_isready -U postgres"},
+			want:  []string{"sh", "-c", "pg_isready -U postgres"},
 		},
 		{
 			name:  "single-element array — exec verbatim",
@@ -671,7 +671,7 @@ func TestContainerCommandOverride_Shell(t *testing.T) {
 	}
 	defer func() { _ = c.Stop() }()
 
-	want := []string{"sh", "-c", "exec npm run dev"}
+	want := []string{"sh", "-c", "npm run dev"}
 	if !slices.Equal(gotCfg.Cmd, want) {
 		t.Errorf("Cmd = %v, want %v", gotCfg.Cmd, want)
 	}

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -470,7 +470,7 @@ func TestBuildExecCmd(t *testing.T) {
 		{
 			name:  "string form — sh -c wrap",
 			input: config.StringOrSlice{Args: []string{"pg_isready", "-U", "postgres"}, Shell: true},
-			want:  []string{"sh", "-c", "pg_isready -U postgres"},
+			want:  []string{"sh", "-c", "exec pg_isready -U postgres"},
 		},
 		{
 			name:  "single-element array — exec verbatim",
@@ -671,7 +671,7 @@ func TestContainerCommandOverride_Shell(t *testing.T) {
 	}
 	defer func() { _ = c.Stop() }()
 
-	want := []string{"sh", "-c", "npm run dev"}
+	want := []string{"sh", "-c", "exec npm run dev"}
 	if !slices.Equal(gotCfg.Cmd, want) {
 		t.Errorf("Cmd = %v, want %v", gotCfg.Cmd, want)
 	}

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -652,3 +652,73 @@ func TestContainerOnCrashNotCalledOnHealthyManualStop(t *testing.T) {
 		t.Errorf("onCrash should NOT fire on healthy manual stop; got %d", crashCount)
 	}
 }
+
+func TestContainerCommandOverride_Shell(t *testing.T) {
+	var gotCfg ContainerConfig
+	m := &mockAPI{
+		CreateContainerFn: func(_ context.Context, cfg ContainerConfig) (string, error) {
+			gotCfg = cfg
+			return "cid", nil
+		},
+	}
+	svc := config.Service{
+		Image:   "node:20",
+		Command: config.StringOrSlice{Args: []string{"npm run dev"}, Shell: true},
+	}
+	c := NewContainer("web", svc, m, "", func() {}, func() {})
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	want := []string{"sh", "-c", "npm run dev"}
+	if !slices.Equal(gotCfg.Cmd, want) {
+		t.Errorf("Cmd = %v, want %v", gotCfg.Cmd, want)
+	}
+}
+
+func TestContainerCommandOverride_Exec(t *testing.T) {
+	var gotCfg ContainerConfig
+	m := &mockAPI{
+		CreateContainerFn: func(_ context.Context, cfg ContainerConfig) (string, error) {
+			gotCfg = cfg
+			return "cid", nil
+		},
+	}
+	svc := config.Service{
+		Image:   "node:20",
+		Command: config.StringOrSlice{Args: []string{"npm", "run", "dev"}, Shell: false},
+	}
+	c := NewContainer("web", svc, m, "", func() {}, func() {})
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	want := []string{"npm", "run", "dev"}
+	if !slices.Equal(gotCfg.Cmd, want) {
+		t.Errorf("Cmd = %v, want %v", gotCfg.Cmd, want)
+	}
+}
+
+func TestContainerCommandOverride_Unset(t *testing.T) {
+	var gotCfg ContainerConfig
+	m := &mockAPI{
+		CreateContainerFn: func(_ context.Context, cfg ContainerConfig) (string, error) {
+			gotCfg = cfg
+			return "cid", nil
+		},
+	}
+	svc := config.Service{
+		Image: "node:20",
+	}
+	c := NewContainer("web", svc, m, "", func() {}, func() {})
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	if gotCfg.Cmd != nil {
+		t.Errorf("Cmd = %v, want nil (image default)", gotCfg.Cmd)
+	}
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -8,6 +8,7 @@ import (
 type ContainerConfig struct {
 	Name           string
 	Image          string
+	Cmd            []string
 	Env            map[string]string
 	Ports          []PortMapping
 	Volumes        []string

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -6,16 +6,15 @@ import (
 )
 
 type ContainerConfig struct {
-	Name             string
-	Image            string
-	Cmd              []string
-	Env              map[string]string
-	Ports            []PortMapping
-	Volumes          []string // bind mounts (host:container) and named volumes (name:container)
-	AnonymousVolumes []string // container paths; Docker creates anonymous volumes to mask bind-mount paths
-	Labels           map[string]string
-	Network          string   // "lokl-{project}"; empty = default bridge
-	NetworkAliases   []string // DNS aliases inside the project network (e.g. service name)
+	Name           string
+	Image          string
+	Cmd            []string
+	Env            map[string]string
+	Ports          []PortMapping
+	Volumes        []string // bind mounts (host:container) and named volumes (name:container)
+	Labels         map[string]string
+	Network        string   // "lokl-{project}"; empty = default bridge
+	NetworkAliases []string // DNS aliases inside the project network (e.g. service name)
 }
 
 type PortMapping struct {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -6,15 +6,16 @@ import (
 )
 
 type ContainerConfig struct {
-	Name           string
-	Image          string
-	Cmd            []string
-	Env            map[string]string
-	Ports          []PortMapping
-	Volumes        []string
-	Labels         map[string]string
-	Network        string   // "lokl-{project}"; empty = default bridge
-	NetworkAliases []string // DNS aliases inside the project network (e.g. service name)
+	Name             string
+	Image            string
+	Cmd              []string
+	Env              map[string]string
+	Ports            []PortMapping
+	Volumes          []string // bind mounts (host:container) and named volumes (name:container)
+	AnonymousVolumes []string // container paths; Docker creates anonymous volumes to mask bind-mount paths
+	Labels           map[string]string
+	Network          string   // "lokl-{project}"; empty = default bridge
+	NetworkAliases   []string // DNS aliases inside the project network (e.g. service name)
 }
 
 type PortMapping struct {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -97,6 +99,17 @@ func (p *Process) Start() error {
 	}
 
 	p.cmd.Env = p.buildEnv()
+
+	// Resolve exec-form Args[0] against the service's PATH, since exec.Command
+	// only consulted the parent PATH before cmd.Env was set.
+	if !p.config.Command.Shell {
+		resolved, err := lookPathWithEnv(p.config.Command.Args[0], p.cmd.Env)
+		if err != nil {
+			return fmt.Errorf("process %s: %w", p.name, err)
+		}
+		p.cmd.Path = resolved
+		p.cmd.Err = nil
+	}
 
 	p.logs = runner.NewLogs(maxLogLines)
 
@@ -218,6 +231,31 @@ func (p *Process) Stop() error {
 	p.onChange()
 
 	return nil
+}
+
+func lookPathWithEnv(name string, env []string) (string, error) {
+	if strings.ContainsRune(name, '/') {
+		return name, nil
+	}
+	var pathVar string
+	for _, e := range env {
+		if rest, ok := strings.CutPrefix(e, "PATH="); ok {
+			pathVar = rest
+		}
+	}
+	if pathVar == "" {
+		return exec.LookPath(name)
+	}
+	for _, dir := range filepath.SplitList(pathVar) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("executable %q not found in PATH", name)
 }
 
 func (p *Process) buildEnv() []string {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -85,7 +85,11 @@ func (p *Process) Start() error {
 
 	// exec replaces the shell so there's one process to manage, not sh + child.
 	// Setpgid isolates the process tree for clean group-kill on shutdown.
-	p.cmd = exec.Command("sh", "-c", "exec "+p.config.Command)
+	if p.config.Command.Shell {
+		p.cmd = exec.Command("sh", "-c", "exec "+p.config.Command.Args[0])
+	} else {
+		p.cmd = exec.Command(p.config.Command.Args[0], p.config.Command.Args[1:]...)
+	}
 	p.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if p.config.Path != "" {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -88,7 +88,7 @@ func (p *Process) Start() error {
 	// exec replaces the shell so there's one process to manage, not sh + child.
 	// Setpgid isolates the process tree for clean group-kill on shutdown.
 	if p.config.Command.Shell {
-		p.cmd = exec.Command("sh", "-c", "exec "+p.config.Command.Args[0])
+		p.cmd = exec.Command("sh", "-c", "exec "+strings.Join(p.config.Command.Args, " "))
 	} else {
 		p.cmd = exec.Command(p.config.Command.Args[0], p.config.Command.Args[1:]...)
 	}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -101,10 +101,13 @@ func (p *Process) Start() error {
 	p.cmd.Env = p.buildEnv()
 
 	// Resolve exec-form Args[0] against the service's PATH, since exec.Command
-	// only consulted the parent PATH before cmd.Env was set.
+	// only consulted the parent PATH before cmd.Env was set. Relative PATH
+	// entries are resolved against the service's working directory so that
+	// `./node_modules/.bin` works with `path: ./frontend`.
 	if !p.config.Command.Shell {
-		resolved, err := lookPathWithEnv(p.config.Command.Args[0], p.cmd.Env)
+		resolved, err := lookPathWithEnv(p.config.Command.Args[0], p.cmd.Env, p.cmd.Dir)
 		if err != nil {
+			p.state = runner.StateFailed
 			return fmt.Errorf("process %s: %w", p.name, err)
 		}
 		p.cmd.Path = resolved
@@ -233,7 +236,7 @@ func (p *Process) Stop() error {
 	return nil
 }
 
-func lookPathWithEnv(name string, env []string) (string, error) {
+func lookPathWithEnv(name string, env []string, cwd string) (string, error) {
 	if strings.ContainsRune(name, '/') {
 		return name, nil
 	}
@@ -249,6 +252,9 @@ func lookPathWithEnv(name string, env []string) (string, error) {
 	for _, dir := range filepath.SplitList(pathVar) {
 		if dir == "" {
 			dir = "."
+		}
+		if !filepath.IsAbs(dir) && cwd != "" {
+			dir = filepath.Join(cwd, dir)
 		}
 		candidate := filepath.Join(dir, name)
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -258,6 +258,11 @@ func lookPathWithEnv(name string, env []string, cwd string) (string, error) {
 		}
 		candidate := filepath.Join(dir, name)
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			// Return an absolute path so the child doesn't re-resolve it
+			// relative to cmd.Dir (which would double-prefix).
+			if abs, absErr := filepath.Abs(candidate); absErr == nil {
+				candidate = abs
+			}
 			return candidate, nil
 		}
 	}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -230,3 +230,27 @@ func TestProcessExecForm(t *testing.T) {
 	}
 	t.Errorf("expected 'hello-exec' in logs, got: %v", logs)
 }
+
+func TestLookPathWithEnv(t *testing.T) {
+	dir := t.TempDir()
+	bin := dir + "/mycli"
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := lookPathWithEnv("mycli", []string{"PATH=" + dir})
+	if err != nil {
+		t.Fatalf("lookPathWithEnv: %v", err)
+	}
+	if got != bin {
+		t.Errorf("got %q, want %q", got, bin)
+	}
+
+	if _, err := lookPathWithEnv("mycli", []string{"PATH=/nowhere"}); err == nil {
+		t.Errorf("expected not-found error for missing PATH entry")
+	}
+
+	if got, _ := lookPathWithEnv("/usr/bin/absolute", []string{"PATH=/x"}); got != "/usr/bin/absolute" {
+		t.Errorf("absolute path should pass through, got %q", got)
+	}
+}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -272,6 +273,37 @@ func TestLookPathWithEnvRelativeToCwd(t *testing.T) {
 	}
 	if got != bin {
 		t.Errorf("got %q, want %q", got, bin)
+	}
+}
+
+func TestLookPathWithEnvReturnsAbsolute(t *testing.T) {
+	root := t.TempDir()
+	sub := root + "/frontend/node_modules/.bin"
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bin := sub + "/vite"
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Simulate a relative cwd like `./frontend`: if the helper returned a
+	// relative path, cmd.Dir would re-resolve it and look in frontend/frontend.
+	oldWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	got, err := lookPathWithEnv("vite", []string{"PATH=./node_modules/.bin"}, "./frontend")
+	if err != nil {
+		t.Fatalf("lookPathWithEnv: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("got %q, want absolute path", got)
+	}
+	if !strings.HasSuffix(got, "/frontend/node_modules/.bin/vite") {
+		t.Errorf("got %q, want suffix /frontend/node_modules/.bin/vite", got)
 	}
 }
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -5,13 +5,22 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shahin-bayat/lokl/internal/config"
 	"github.com/shahin-bayat/lokl/internal/runner"
 )
 
+func shCmd(s string) config.StringOrSlice {
+	return config.StringOrSlice{Args: []string{s}, Shell: true}
+}
+
+func execCmd(args ...string) config.StringOrSlice {
+	return config.StringOrSlice{Args: args, Shell: false}
+}
+
 func TestNewProcess(t *testing.T) {
-	p := New("web", config.Service{Command: "npm start"}, func() {}, func() {})
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, func() {})
 	if p.IsRunning() {
 		t.Error("new process should not be running")
 	}
@@ -25,7 +34,7 @@ func TestNewProcess(t *testing.T) {
 
 func TestBuildEnv(t *testing.T) {
 	p := New("web", config.Service{
-		Command: "npm start",
+		Command: shCmd("npm start"),
 		Env:     map[string]string{"NODE_ENV": "production", "PORT": "3000"},
 	}, func() {}, func() {})
 
@@ -54,7 +63,7 @@ func TestBuildEnv(t *testing.T) {
 func TestOnCrashCalledOnHealthyToCrash(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
-	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, onCrash)
 
 	p.mu.Lock()
 	p.state = runner.StateRunning
@@ -78,7 +87,7 @@ func TestOnCrashCalledOnHealthyToCrash(t *testing.T) {
 func TestOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
-	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, onCrash)
 
 	p.mu.Lock()
 	p.state = runner.StateRunning
@@ -104,7 +113,7 @@ func TestOnCrashCalledOnNeverHealthyExit(t *testing.T) {
 func TestOnCrashCalledOnHealthyProcessExit(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
-	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, onCrash)
 
 	// Simulate: process was healthy (e.g. no health check) and crashes.
 	p.mu.Lock()
@@ -131,7 +140,7 @@ func TestOnCrashCalledOnHealthyProcessExit(t *testing.T) {
 func TestOnCrashNotCalledOnManualStop(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
-	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, onCrash)
 
 	p.mu.Lock()
 	p.state = runner.StateRunning
@@ -156,7 +165,7 @@ func TestOnCrashNotCalledOnManualStop(t *testing.T) {
 func TestOnCrashNotCalledOnHealthyManualStop(t *testing.T) {
 	var crashCount int
 	onCrash := func() { crashCount++ }
-	p := New("web", config.Service{Command: "npm start"}, func() {}, onCrash)
+	p := New("web", config.Service{Command: shCmd("npm start")}, func() {}, onCrash)
 
 	p.mu.Lock()
 	p.state = runner.StateRunning
@@ -193,4 +202,31 @@ func TestCheckPortFree(t *testing.T) {
 	if err := checkPortFree(port); err == nil {
 		t.Errorf("port %d should be occupied", port)
 	}
+}
+
+func TestProcessExecForm(t *testing.T) {
+	p := New("echo", config.Service{Command: execCmd("/bin/echo", "hello-exec")}, func() {}, func() {})
+
+	if err := p.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		p.mu.Lock()
+		st := p.state
+		p.mu.Unlock()
+		if st != runner.StateRunning && st != runner.StateStarting {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	logs := p.Logs()
+	for _, line := range logs {
+		if strings.Contains(line, "hello-exec") {
+			return
+		}
+	}
+	t.Errorf("expected 'hello-exec' in logs, got: %v", logs)
 }

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shahin-bayat/lokl/internal/runner"
 )
 
+//nolint:unparam // fixture helper; kept for symmetry with execCmd
 func shCmd(s string) config.StringOrSlice {
 	return config.StringOrSlice{Args: []string{s}, Shell: true}
 }

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -238,7 +238,7 @@ func TestLookPathWithEnv(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	got, err := lookPathWithEnv("mycli", []string{"PATH=" + dir})
+	got, err := lookPathWithEnv("mycli", []string{"PATH=" + dir}, "")
 	if err != nil {
 		t.Fatalf("lookPathWithEnv: %v", err)
 	}
@@ -246,11 +246,45 @@ func TestLookPathWithEnv(t *testing.T) {
 		t.Errorf("got %q, want %q", got, bin)
 	}
 
-	if _, err := lookPathWithEnv("mycli", []string{"PATH=/nowhere"}); err == nil {
+	if _, err := lookPathWithEnv("mycli", []string{"PATH=/nowhere"}, ""); err == nil {
 		t.Errorf("expected not-found error for missing PATH entry")
 	}
 
-	if got, _ := lookPathWithEnv("/usr/bin/absolute", []string{"PATH=/x"}); got != "/usr/bin/absolute" {
+	if got, _ := lookPathWithEnv("/usr/bin/absolute", []string{"PATH=/x"}, ""); got != "/usr/bin/absolute" {
 		t.Errorf("absolute path should pass through, got %q", got)
+	}
+}
+
+func TestLookPathWithEnvRelativeToCwd(t *testing.T) {
+	cwd := t.TempDir()
+	nodeModulesBin := cwd + "/node_modules/.bin"
+	if err := os.MkdirAll(nodeModulesBin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bin := nodeModulesBin + "/vite"
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := lookPathWithEnv("vite", []string{"PATH=./node_modules/.bin"}, cwd)
+	if err != nil {
+		t.Fatalf("lookPathWithEnv: %v", err)
+	}
+	if got != bin {
+		t.Errorf("got %q, want %q", got, bin)
+	}
+}
+
+func TestProcessExecFormMissingBinary(t *testing.T) {
+	p := New("bad", config.Service{Command: execCmd("definitely-not-a-real-binary-xyz")}, func() {}, func() {})
+	err := p.Start()
+	if err == nil {
+		t.Fatalf("expected error for missing binary")
+	}
+	p.mu.Lock()
+	st := p.state
+	p.mu.Unlock()
+	if st != runner.StateFailed {
+		t.Errorf("state = %v, want StateFailed", st)
 	}
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -150,6 +150,10 @@ func (m *mockProxy) IsServiceProxyEnabled(name string) bool {
 
 // --- Helpers ---
 
+func shCmd(s string) config.StringOrSlice {
+	return config.StringOrSlice{Args: []string{s}, Shell: true}
+}
+
 func newTestSupervisor(cfg *config.Config, factory ProcessFactory, proxy ProxyManager) *Supervisor {
 	if proxy == nil {
 		proxy = &mockProxy{}
@@ -184,7 +188,7 @@ func TestStartService(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -204,7 +208,7 @@ func TestStartServiceIdempotent(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -234,7 +238,7 @@ func TestStartServiceStartError(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -255,7 +259,7 @@ func TestStopService(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -273,7 +277,7 @@ func TestStopService(t *testing.T) {
 
 func TestStopServiceNotRunning(t *testing.T) {
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, nil, nil)
 
@@ -292,7 +296,7 @@ func TestRestartService(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -316,8 +320,8 @@ func TestStart(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"db":  {Command: "postgres"},
-		"web": {Command: "npm start", DependsOn: []string{"db"}},
+		"db":  {Command: shCmd("postgres")},
+		"web": {Command: shCmd("npm start"), DependsOn: []string{"db"}},
 	})
 
 	proxy := &mockProxy{
@@ -346,8 +350,8 @@ func TestStartSkipsAutoStartFalse(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"web":    {Command: "npm start"},
-		"worker": {Command: "worker", AutoStart: boolPtr(false)},
+		"web":    {Command: shCmd("npm start")},
+		"worker": {Command: shCmd("worker"), AutoStart: boolPtr(false)},
 	})
 
 	proxy := &mockProxy{
@@ -386,8 +390,8 @@ func TestStartServiceFailureTriggersCleanup(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"db":  {Command: "postgres"},
-		"web": {Command: "npm start", DependsOn: []string{"db"}},
+		"db":  {Command: shCmd("postgres")},
+		"web": {Command: shCmd("npm start"), DependsOn: []string{"db"}},
 	})
 
 	proxy := &mockProxy{
@@ -413,7 +417,7 @@ func TestStartNoProxy(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -436,7 +440,7 @@ func TestStop(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, proxy)
 
@@ -461,7 +465,7 @@ func TestToggleProxy(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"web": {Command: "npm start", Subdomain: "app"},
+		"web": {Command: shCmd("npm start"), Subdomain: "app"},
 	})
 	s := newTestSupervisor(cfg, nil, proxy)
 
@@ -501,7 +505,7 @@ func TestToggleProxyNoRoute(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, nil, proxy)
 
@@ -524,8 +528,8 @@ func TestServices(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"web": {Command: "npm start", Port: 3000, Subdomain: "app"},
-		"api": {Command: "go run .", Port: 8080, Subdomain: "api"},
+		"web": {Command: shCmd("npm start"), Port: 3000, Subdomain: "app"},
+		"api": {Command: shCmd("go run ."), Port: 8080, Subdomain: "api"},
 	})
 	s := newTestSupervisor(cfg, factory, proxy)
 
@@ -561,7 +565,7 @@ func TestServicesWithPathPrefix(t *testing.T) {
 
 	cfg := proxyConfig(map[string]config.Service{
 		"web": {
-			Command:   "npm start",
+			Command:   shCmd("npm start"),
 			Port:      3000,
 			Subdomain: "app",
 			Rewrite:   &config.RewriteConfig{StripPrefix: "web"},
@@ -583,7 +587,7 @@ func TestServiceLogs(t *testing.T) {
 	}
 
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, factory, nil)
 
@@ -596,7 +600,7 @@ func TestServiceLogs(t *testing.T) {
 
 func TestServiceLogsNotRunning(t *testing.T) {
 	cfg := simpleConfig(map[string]config.Service{
-		"web": {Command: "npm start"},
+		"web": {Command: shCmd("npm start")},
 	})
 	s := newTestSupervisor(cfg, nil, nil)
 

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -235,6 +235,7 @@ services:
 | Field | Type | Description |
 |-------|------|-------------|
 | `image` | string | Docker image |
+| `command` | string or list | Shell command (string → `sh -c`) or exec args (list). Allowed with `image` to override the image's default command. |
 | `ports` | list | Port mappings (`host:container`) |
 | `port` | int | Host port for proxy routing and health checks |
 | `env` | map | Environment variables |
@@ -299,6 +300,24 @@ services:
 ```
 
 `health.path` and `health.command` are mutually exclusive — use one or the other.
+
+#### Overriding a container's command
+
+`command` is allowed alongside `image`. It overrides the image's default `CMD` while preserving `ENTRYPOINT` — matching `docker run image cmd...` and Docker Compose's `command:` field.
+
+```yaml
+services:
+  api:
+    image: node:20
+    command: "npm run dev"          # string → sh -c inside the container
+  worker:
+    image: node:20
+    command: ["node", "worker.js"]  # list → direct exec, no shell
+```
+
+**Caveat:** images with an `ENTRYPOINT` (e.g. `python`, `node`, `postgres`) prepend it to the command. Shell-form `command: "script.py"` on a `python` image becomes `python /bin/sh -c "script.py"` — use the list form or a custom image when this matters.
+
+**Requirement for shell form:** the image must contain `/bin/sh` (most do; `scratch` and some distroless images do not).
 
 #### Container Networking
 

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -240,7 +240,7 @@ services:
 | `port` | int | Host port for proxy routing and health checks |
 | `env` | map | Environment variables |
 | `env_file` | list | Paths to `.env` files to load |
-| `volumes` | list | Volume mounts (`host:container`) |
+| `volumes` | list | Volume mounts. `host:container` bind, `name:container` named, or bare `/container/path` anonymous (masks dir from outer bind, e.g. `vendor/`, `node_modules/`). |
 | `subdomain` | string | Subdomain for proxy routing |
 | `depends_on` | list | Services to start first |
 | `health` | object | Health check configuration |

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -108,6 +108,20 @@ services:
 
 `health.path` and `health.command` are mutually exclusive. Use `health.command` for data services (databases, caches) that have no HTTP endpoint. String form wraps in `sh -c`; array form execs directly.
 
+Container command can be overridden: set `command:` together with `image:`. String form wraps `sh -c` inside the container; array form execs directly. Image `ENTRYPOINT` is preserved (matches Docker Compose and `docker run image cmd...`).
+
+```yaml
+services:
+  api:
+    image: node:20
+    command: "npm run dev"          # overrides image CMD
+  worker:
+    image: node:20
+    command: ["node", "worker.js"]  # exec form, no shell
+```
+
+**Caveat:** images with an `ENTRYPOINT` (e.g. `python`, `node`, `postgres`) prepend it to the command. Shell-form `command: "script.py"` on a `python` image becomes `python /bin/sh -c "script.py"` — use the list form or a custom image when this matters.
+
 Containers in the same lokl project share a bridge network (`lokl-{name}`). Reach other containers by service name (e.g., `DB_HOST: db`).
 
 ## CLI commands

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -68,7 +68,7 @@ services:
 :::note
 - When `port` is set with `ports`, the port value must appear as a host port in one of the mappings.
 - Volume container paths must be absolute (e.g., `/var/lib/data`, not `data`).
-- "Mask" volumes (bare container path, e.g. `- /var/www/html/vendor`) hide a directory from an outer bind mount — useful for `vendor/` or `node_modules/` inside a source bind. lokl backs these with deterministically-named Docker volumes (`lokl-mask-<service>-<escaped-path>`) so the contents survive container recreation. Remove manually via `docker volume rm` when you want to reset.
+- "Mask" volumes (bare container path, e.g. `- /var/www/html/vendor`) hide a directory from an outer bind mount — useful for `vendor/` or `node_modules/` inside a source bind. lokl backs these with deterministically-named Docker volumes — `lokl-<project>-mask-<service>-<escaped-path>` when a project network is in use, falling back to `lokl-mask-<service>-<escaped-path>` otherwise — so the contents survive container recreation. Remove manually via `docker volume rm` when you want to reset.
 - Docker must be running to use container-based services.
 :::
 

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -58,7 +58,7 @@ services:
 | `port` | int | Host port for proxy routing and health checks |
 | `env` | map | Environment variables |
 | `env_file` | list | Paths to `.env` files to load |
-| `volumes` | list | Volume mounts (`host:container`) |
+| `volumes` | list | Volume mounts. `host:container` for bind mounts, `name:container` for named volumes, bare `/container/path` for anonymous volumes (mask a dir from an outer bind mount). |
 | `subdomain` | string | Subdomain for proxy routing |
 | `depends_on` | list | Services to start first |
 | `health` | object | Health check configuration (see below) |
@@ -68,6 +68,7 @@ services:
 :::note
 - When `port` is set with `ports`, the port value must appear as a host port in one of the mappings.
 - Volume container paths must be absolute (e.g., `/var/lib/data`, not `data`).
+- Anonymous volumes (bare container path, e.g. `- /var/www/html/vendor`) let Docker mask a directory from an outer bind mount — useful for `vendor/` or `node_modules/` inside a source bind.
 - Docker must be running to use container-based services.
 :::
 

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -21,7 +21,7 @@ services:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `command` | string | Shell command to run |
+| `command` | string or list | Shell command (string → `sh -c`) or exec args (list). Allowed with `image` to override the image's default command. |
 | `path` | string | Working directory (relative to config) |
 | `port` | int | Port the service listens on |
 | `env` | map | Environment variables |
@@ -53,6 +53,7 @@ services:
 | Field | Type | Description |
 |-------|------|-------------|
 | `image` | string | Docker image |
+| `command` | string or list | Override the image's default `CMD`. String → `sh -c` inside container; list → direct exec. |
 | `ports` | list | Port mappings (`host:container`) |
 | `port` | int | Host port for proxy routing and health checks |
 | `env` | map | Environment variables |
@@ -106,6 +107,24 @@ services:
       timeout: 5s
       retries: 3
 ```
+
+### Overriding a container's command
+
+`command` is allowed alongside `image`. It overrides the image's default `CMD` while preserving `ENTRYPOINT` — matching `docker run image cmd...` and Docker Compose's `command:` field.
+
+```yaml
+services:
+  api:
+    image: node:20
+    command: "npm run dev"          # string → sh -c inside the container
+  worker:
+    image: node:20
+    command: ["node", "worker.js"]  # list → direct exec, no shell
+```
+
+**Caveat:** images with an `ENTRYPOINT` (e.g. `python`, `node`, `postgres`) prepend it to the command. Shell-form `command: "script.py"` on a `python` image becomes `python /bin/sh -c "script.py"` — use the list form or a custom image when this matters.
+
+**Requirement for shell form:** the image must contain `/bin/sh` (most do; `scratch` and some distroless images do not).
 
 ### Exec check (`health.command`)
 

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -127,6 +127,8 @@ services:
 
 **Requirement for shell form:** the image must contain `/bin/sh` (most do; `scratch` and some distroless images do not).
 
+**Signal handling:** with shell form, `/bin/sh` is PID 1. `docker stop` sends `SIGTERM` to `sh`, which may not forward it to the child — the container waits out the stop grace period before `SIGKILL`. Use the list form for fast graceful shutdown on a single binary.
+
 ### Exec check (`health.command`)
 
 For data services that have no HTTP endpoint (databases, caches):

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -68,7 +68,7 @@ services:
 :::note
 - When `port` is set with `ports`, the port value must appear as a host port in one of the mappings.
 - Volume container paths must be absolute (e.g., `/var/lib/data`, not `data`).
-- Anonymous volumes (bare container path, e.g. `- /var/www/html/vendor`) let Docker mask a directory from an outer bind mount — useful for `vendor/` or `node_modules/` inside a source bind.
+- "Mask" volumes (bare container path, e.g. `- /var/www/html/vendor`) hide a directory from an outer bind mount — useful for `vendor/` or `node_modules/` inside a source bind. lokl backs these with deterministically-named Docker volumes (`lokl-mask-<service>-<escaped-path>`) so the contents survive container recreation. Remove manually via `docker volume rm` when you want to reset.
 - Docker must be running to use container-based services.
 :::
 


### PR DESCRIPTION
## Summary

- **Container `command:` override.** Allow `command:` alongside `image:` to override an image's default `CMD` while preserving `ENTRYPOINT` — matches Compose and `docker run image cmd...`. Accepts string (shell form) or list (exec form).
- **Unified `StringOrSlice` command shape** across process + container services. Same YAML syntax already used by `health.command`.
- **Process exec-form.** List-form commands bypass `sh -c` and exec the binary directly. Relative PATH entries resolve against the service's working dir; returns absolute path so `cmd.Dir` doesn't double-prefix.
- **Masking volumes.** Bare container paths (`- /var/www/html/vendor`) now work — backed by project-scoped named volumes (`lokl-<project>-mask-<service>-<path>`), so dependencies survive container recreation.
- **Validation tightening.** Reject empty service `command`; reject `path:` with `image:` (silently ignored before).

## Behavior notes

- Shell form in containers keeps `sh` as PID 1 — signals may not forward. Use list form for fast graceful shutdown. Documented in `config/services.md`.
- `ENTRYPOINT` images (`python`, `node`, `postgres`) prepend their entrypoint to `command`. Standard Docker behavior; call out the footgun with list form as the escape.

## Test plan

- [x] `make check` green
- [x] `./lokl validate` on a real multi-service Laravel config (postgres/redis/minio/web/horizon/scheduler)
- [x] Container command override (`command: ["server","/data","--console-address",":9001"]` on `minio/minio:latest`) — previously required custom Dockerfile with `CMD`
- [x] Masking volumes preserve `vendor/` and `node_modules/` across `lokl down` + `lokl up`
- [x] Six rounds of Codex review iterated to green

## Files

16 commits, 17 files. Diff-shortstat at merge time: ~17 files / ~540 lines.