### PR TITLE
feat(proxy): wildcard subdomain routing (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ services:
       retries: 10
 ```
 
+### Wildcard subdomains (multi-tenant apps)
+
+```yaml
+services:
+  web:
+    command: php artisan serve
+    subdomain:
+      - sellify.shop
+      - "*.sellify.shop"
+    port: 8000
+```
+
+`sudo lokl dns setup` writes `/etc/hosts` **and** `/etc/resolver/sellify.shop`; `lokl up` then runs an in-process DNS listener so every subdomain resolves locally. Cert SANs cover both apex and wildcard.
+
+macOS only for now; Linux support (systemd-resolved) is coming in a follow-up release.
+
 Containers in the same lokl project share a bridge network (`lokl-{name}`).
 They can reach each other by service name — no need to expose ports between containers:
 

--- a/cmd/lokl/dns.go
+++ b/cmd/lokl/dns.go
@@ -58,6 +58,9 @@ func runDNSSetup(cmd *cobra.Command, args []string) error {
 	chownToSudoUser(".lokl")
 
 	fmt.Printf("✓ Added %d entries to /etc/hosts\n", len(domains))
+	if n := p.WildcardParentCount(); n > 0 {
+		fmt.Printf("✓ Wrote %d resolver file(s) under /etc/resolver\n", n)
+	}
 	return nil
 }
 
@@ -102,6 +105,9 @@ func runDNSRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("✓ Removed DNS entries from /etc/hosts")
+	if n := p.WildcardParentCount(); n > 0 {
+		fmt.Println("✓ Removed resolver files under /etc/resolver")
+	}
 	fmt.Println("\nTo flush DNS cache:")
 	if runtime.GOOS == "darwin" {
 		fmt.Println("  sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,8 @@ type Service struct {
 	Image   string        `yaml:"image"`
 	Path    string        `yaml:"path"`
 
-	Port      int    `yaml:"port"`
-	Subdomain string `yaml:"subdomain"`
+	Port       int        `yaml:"port"`
+	Subdomains Subdomains `yaml:"subdomain"`
 
 	Rewrite *RewriteConfig `yaml:"rewrite"`
 
@@ -78,6 +78,26 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (s StringOrSlice) IsSet() bool { return len(s.Args) > 0 }
+
+// Subdomains accepts either a YAML scalar or sequence.
+// Stored internally as a flat string slice.
+type Subdomains []string
+
+func (s *Subdomains) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*s = []string{value.Value}
+	case yaml.SequenceNode:
+		var list []string
+		if err := value.Decode(&list); err != nil {
+			return err
+		}
+		*s = list
+	default:
+		return fmt.Errorf("subdomain: expected string or sequence, got %v", value.Tag)
+	}
+	return nil
+}
 
 type HealthConfig struct {
 	Path     string        `yaml:"path"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,14 +79,16 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 
 func (s StringOrSlice) IsSet() bool { return len(s.Args) > 0 }
 
-// Subdomains accepts either a YAML scalar or sequence.
-// Stored internally as a flat string slice.
 type Subdomains []string
 
 func (s *Subdomains) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
 	case yaml.ScalarNode:
-		*s = []string{value.Value}
+		var str string
+		if err := value.Decode(&str); err != nil {
+			return err
+		}
+		*s = []string{str}
 	case yaml.SequenceNode:
 		var list []string
 		if err := value.Decode(&list); err != nil {
@@ -94,7 +96,7 @@ func (s *Subdomains) UnmarshalYAML(value *yaml.Node) error {
 		}
 		*s = list
 	default:
-		return fmt.Errorf("subdomain: expected string or sequence, got %v", value.Tag)
+		return fmt.Errorf("subdomain must be a string or list of strings, got %v", value.Tag)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -524,7 +523,7 @@ func TestSubdomainsUnmarshal(t *testing.T) {
 	}{
 		{"scalar", "subdomain: api.x.test", []string{"api.x.test"}},
 		{"list", "subdomain:\n  - x.test\n  - \"*.x.test\"", []string{"x.test", "*.x.test"}},
-		{"missing", "", nil},
+		{"null", "subdomain:", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -532,9 +531,17 @@ func TestSubdomainsUnmarshal(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(tc.yaml), &svc); err != nil {
 				t.Fatalf("unmarshal: %v", err)
 			}
-			if !reflect.DeepEqual([]string(svc.Subdomains), tc.want) {
+			if !slices.Equal(svc.Subdomains, tc.want) {
 				t.Fatalf("got %v want %v", svc.Subdomains, tc.want)
 			}
 		})
 	}
+
+	t.Run("mapping rejected", func(t *testing.T) {
+		var svc Service
+		err := yaml.Unmarshal([]byte("subdomain: {foo: bar}"), &svc)
+		if err == nil {
+			t.Fatalf("expected error for mapping, got nil")
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -118,7 +119,7 @@ func TestValidate(t *testing.T) {
 			name: "subdomain without proxy domain",
 			cfg: Config{
 				Name:     "test",
-				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomain: "app", Port: 3000}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomains: Subdomains{"app"}, Port: 3000}},
 			},
 			wantErr: "has subdomain but proxy.domain is not configured",
 		},
@@ -127,7 +128,7 @@ func TestValidate(t *testing.T) {
 			cfg: Config{
 				Name:     "test",
 				Proxy:    ProxyConfig{Domain: "test.dev"},
-				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomain: "app"}},
+				Services: map[string]Service{"a": {Command: cmdStr("x"), Subdomains: Subdomains{"app"}}},
 			},
 			wantErr: "port is required when subdomain is set",
 		},
@@ -247,8 +248,8 @@ func TestValidate(t *testing.T) {
 				Name:  "test",
 				Proxy: ProxyConfig{Domain: "test.dev"},
 				Services: map[string]Service{
-					"a": {Command: cmdStr("x"), Subdomain: "client", Port: 8080},
-					"b": {Command: cmdStr("y"), Subdomain: "client", Port: 8081},
+					"a": {Command: cmdStr("x"), Subdomains: Subdomains{"client"}, Port: 8080},
+					"b": {Command: cmdStr("y"), Subdomains: Subdomains{"client"}, Port: 8081},
 				},
 			},
 			wantErr: "same subdomain with no prefix",
@@ -259,8 +260,8 @@ func TestValidate(t *testing.T) {
 				Name:  "test",
 				Proxy: ProxyConfig{Domain: "test.dev"},
 				Services: map[string]Service{
-					"a": {Command: cmdStr("x"), Subdomain: "client", Port: 8080, Rewrite: &RewriteConfig{StripPrefix: "app-a"}},
-					"b": {Command: cmdStr("y"), Subdomain: "client", Port: 8081, Rewrite: &RewriteConfig{StripPrefix: "app-b"}},
+					"a": {Command: cmdStr("x"), Subdomains: Subdomains{"client"}, Port: 8080, Rewrite: &RewriteConfig{StripPrefix: "app-a"}},
+					"b": {Command: cmdStr("y"), Subdomains: Subdomains{"client"}, Port: 8081, Rewrite: &RewriteConfig{StripPrefix: "app-b"}},
 				},
 			},
 			wantErr: "",
@@ -510,6 +511,29 @@ func TestServiceCommandParsing(t *testing.T) {
 			}
 			if s.Command.Shell != tt.wantShell {
 				t.Errorf("shell = %v, want %v", s.Command.Shell, tt.wantShell)
+			}
+		})
+	}
+}
+
+func TestSubdomainsUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{"scalar", "subdomain: api.x.test", []string{"api.x.test"}},
+		{"list", "subdomain:\n  - x.test\n  - \"*.x.test\"", []string{"x.test", "*.x.test"}},
+		{"missing", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var svc Service
+			if err := yaml.Unmarshal([]byte(tc.yaml), &svc); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual([]string(svc.Subdomains), tc.want) {
+				t.Fatalf("got %v want %v", svc.Subdomains, tc.want)
 			}
 		})
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -17,7 +17,7 @@ func validate(cfg *Config) error {
 	}
 
 	for name, svc := range cfg.Services {
-		if svc.Subdomain != "" && cfg.Proxy.Domain == "" {
+		if len(svc.Subdomains) > 0 && cfg.Proxy.Domain == "" {
 			return fmt.Errorf("service %q has subdomain but proxy.domain is not configured", name)
 		}
 	}
@@ -86,7 +86,7 @@ func validateService(name string, svc *Service, services map[string]Service) err
 		return fmt.Errorf("service %q: path is only valid for command-based services; container services cannot set path", name)
 	}
 
-	if svc.Subdomain != "" && svc.Port == 0 {
+	if len(svc.Subdomains) > 0 && svc.Port == 0 {
 		return fmt.Errorf("service %q: port is required when subdomain is set", name)
 	}
 
@@ -206,27 +206,29 @@ func checkDuplicateSubdomains(cfg *Config) error {
 	type key struct{ fqdn, prefix string }
 	seen := make(map[key]string)
 	for name, svc := range cfg.Services {
-		if svc.Subdomain == "" {
-			continue
-		}
-		fqdn := svc.Subdomain
-		if !strings.Contains(fqdn, ".") && cfg.Proxy.Domain != "" {
-			fqdn = svc.Subdomain + "." + cfg.Proxy.Domain
-		}
-		prefix := ""
-		if svc.Rewrite != nil {
-			prefix = strings.Trim(svc.Rewrite.StripPrefix, "/")
-		}
-		k := key{fqdn, prefix}
-		if existing, ok := seen[k]; ok {
-			if prefix == "" {
-				return fmt.Errorf("services %q and %q: same subdomain with no prefix",
-					existing, name)
+		for _, sd := range svc.Subdomains {
+			if sd == "" {
+				continue
 			}
-			return fmt.Errorf("services %q and %q: same subdomain with same prefix %q",
-				existing, name, prefix)
+			fqdn := sd
+			if !strings.Contains(fqdn, ".") && cfg.Proxy.Domain != "" {
+				fqdn = sd + "." + cfg.Proxy.Domain
+			}
+			prefix := ""
+			if svc.Rewrite != nil {
+				prefix = strings.Trim(svc.Rewrite.StripPrefix, "/")
+			}
+			k := key{fqdn, prefix}
+			if existing, ok := seen[k]; ok {
+				if prefix == "" {
+					return fmt.Errorf("services %q and %q: same subdomain with no prefix",
+						existing, name)
+				}
+				return fmt.Errorf("services %q and %q: same subdomain with same prefix %q",
+					existing, name, prefix)
+			}
+			seen[k] = name
 		}
-		seen[k] = name
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -32,6 +32,7 @@ func validate(cfg *Config) error {
 		}
 	}
 
+	// Run after per-service validation so duplicate detection sees only well-formed subdomains.
 	if err := checkDuplicateSubdomains(cfg); err != nil {
 		return err
 	}
@@ -103,7 +104,7 @@ func validateService(name string, svc *Service, services map[string]Service) err
 			}
 			continue
 		}
-		if strings.ContainsAny(sd, "*") {
+		if strings.Contains(sd, "*") {
 			return fmt.Errorf("service %q: invalid subdomain %q", name, sd)
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -26,14 +26,14 @@ func validate(cfg *Config) error {
 		return err
 	}
 
-	if err := checkDuplicateSubdomains(cfg); err != nil {
-		return err
-	}
-
 	for name, svc := range cfg.Services {
 		if err := validateService(name, &svc, cfg.Services); err != nil {
 			return err
 		}
+	}
+
+	if err := checkDuplicateSubdomains(cfg); err != nil {
+		return err
 	}
 
 	return nil
@@ -88,6 +88,24 @@ func validateService(name string, svc *Service, services map[string]Service) err
 
 	if len(svc.Subdomains) > 0 && svc.Port == 0 {
 		return fmt.Errorf("service %q: port is required when subdomain is set", name)
+	}
+
+	seen := map[string]struct{}{}
+	for _, sd := range svc.Subdomains {
+		if _, dup := seen[sd]; dup {
+			return fmt.Errorf("service %q: duplicate subdomain %q", name, sd)
+		}
+		seen[sd] = struct{}{}
+
+		if after, isWild := strings.CutPrefix(sd, "*."); isWild {
+			if err := validateWildcardParent(after); err != nil {
+				return fmt.Errorf("service %q: subdomain %q: %w", name, sd, err)
+			}
+			continue
+		}
+		if strings.ContainsAny(sd, "*") {
+			return fmt.Errorf("service %q: invalid subdomain %q", name, sd)
+		}
 	}
 
 	if svc.Health != nil && svc.Health.Path != "" && svc.Port == 0 {
@@ -228,6 +246,30 @@ func checkDuplicateSubdomains(cfg *Config) error {
 					existing, name, prefix)
 			}
 			seen[k] = name
+		}
+	}
+	return nil
+}
+
+var reservedWildcardParents = map[string]struct{}{
+	"com": {}, "org": {}, "net": {},
+	"local": {}, "localhost": {}, "test": {},
+}
+
+func validateWildcardParent(parent string) error {
+	if parent == "" {
+		return fmt.Errorf("wildcard must have a parent domain")
+	}
+	if _, reserved := reservedWildcardParents[parent]; reserved {
+		return fmt.Errorf("reserved wildcard parent %q", parent)
+	}
+	labels := strings.Split(parent, ".")
+	if len(labels) < 2 {
+		return fmt.Errorf("wildcard parent must have at least two labels")
+	}
+	for _, l := range labels {
+		if l == "" || strings.Contains(l, "*") {
+			return fmt.Errorf("invalid wildcard parent %q", parent)
 		}
 	}
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateWildcardSubdomains(t *testing.T) {
+	tests := []struct {
+		name       string
+		subdomains Subdomains
+		wantErr    string
+	}{
+		{"bare star", Subdomains{"*"}, "invalid subdomain"},
+		{"star dot only", Subdomains{"*."}, "wildcard must have a parent domain"},
+		{"star mid label", Subdomains{"a.*.b"}, "invalid subdomain"},
+		{"trailing star", Subdomains{"foo.*"}, "invalid subdomain"},
+		{"prefix star", Subdomains{"*foo.bar"}, "invalid subdomain"},
+		{"reserved com", Subdomains{"*.com"}, "reserved wildcard parent"},
+		{"reserved local", Subdomains{"*.local"}, "reserved wildcard parent"},
+		{"reserved test", Subdomains{"*.test"}, "reserved wildcard parent"},
+		{"reserved localhost", Subdomains{"*.localhost"}, "reserved wildcard parent"},
+		{"single label parent", Subdomains{"*.singlelabel"}, "at least two labels"},
+
+		{"exact host", Subdomains{"api.x.test"}, ""},
+		{"wildcard two label parent", Subdomains{"*.x.test"}, ""},
+		{"wildcard deep parent", Subdomains{"*.api.x.test"}, ""},
+		{"exact host reserved-looking", Subdomains{"x.test"}, ""},
+
+		{"dup entries", Subdomains{"x.test", "x.test"}, "duplicate subdomain"},
+		{"exact plus wildcard no dup", Subdomains{"x.test", "*.x.test"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Name:  "test",
+				Proxy: ProxyConfig{Domain: "test.dev"},
+				Services: map[string]Service{
+					"a": {Command: cmdStr("x"), Port: 3000, Subdomains: tt.subdomains},
+				},
+			}
+			err := validate(&cfg)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/proxy/certs.go
+++ b/internal/proxy/certs.go
@@ -1,10 +1,14 @@
 package proxy
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 type certManager struct {
@@ -37,8 +41,8 @@ func (c *certManager) generate(primary string, sans []string) (certPath, keyPath
 		return "", "", fmt.Errorf("creating cert directory: %w", err)
 	}
 
-	certPath = c.certPath(primary)
-	keyPath = c.keyPath(primary)
+	certPath = c.certPath(primary, sans)
+	keyPath = c.keyPath(primary, sans)
 
 	if fileExists(certPath) && fileExists(keyPath) {
 		return certPath, keyPath, nil
@@ -55,12 +59,28 @@ func (c *certManager) generate(primary string, sans []string) (certPath, keyPath
 	return certPath, keyPath, nil
 }
 
-func (c *certManager) certPath(domain string) string {
-	return filepath.Join(c.dir, domain+".pem")
+func (c *certManager) certPath(domain string, sans []string) string {
+	return filepath.Join(c.dir, domain+"."+sanHash(sans)+".pem")
 }
 
-func (c *certManager) keyPath(domain string) string {
-	return filepath.Join(c.dir, domain+"-key.pem")
+func (c *certManager) keyPath(domain string, sans []string) string {
+	return filepath.Join(c.dir, domain+"."+sanHash(sans)+"-key.pem")
+}
+
+// sanHash produces a stable short hash of the SAN set so the cert filename
+// changes when the SAN list changes, invalidating the on-disk cache.
+func sanHash(sans []string) string {
+	uniq := make(map[string]struct{}, len(sans))
+	for _, s := range sans {
+		uniq[s] = struct{}{}
+	}
+	sorted := make([]string, 0, len(uniq))
+	for s := range uniq {
+		sorted = append(sorted, s)
+	}
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
+	return hex.EncodeToString(sum[:])[:8]
 }
 
 func (c *certManager) checkMkcert() error {

--- a/internal/proxy/certs.go
+++ b/internal/proxy/certs.go
@@ -28,7 +28,7 @@ func (c *certManager) ensureCA() error {
 	return nil
 }
 
-func (c *certManager) generate(domain string) (certPath, keyPath string, err error) {
+func (c *certManager) generate(primary string, sans []string) (certPath, keyPath string, err error) {
 	if err := c.checkMkcert(); err != nil {
 		return "", "", err
 	}
@@ -37,19 +37,17 @@ func (c *certManager) generate(domain string) (certPath, keyPath string, err err
 		return "", "", fmt.Errorf("creating cert directory: %w", err)
 	}
 
-	certPath = c.certPath(domain)
-	keyPath = c.keyPath(domain)
+	certPath = c.certPath(primary)
+	keyPath = c.keyPath(primary)
 
 	if fileExists(certPath) && fileExists(keyPath) {
 		return certPath, keyPath, nil
 	}
 
-	wildcard := "*." + domain
-	out, err := exec.Command("mkcert",
-		"-cert-file", certPath,
-		"-key-file", keyPath,
-		wildcard, domain,
-	).CombinedOutput()
+	args := []string{"-cert-file", certPath, "-key-file", keyPath}
+	args = append(args, sans...)
+
+	out, err := exec.Command("mkcert", args...).CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("generating certificate: %s: %w", out, err)
 	}

--- a/internal/proxy/certs_test.go
+++ b/internal/proxy/certs_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/shahin-bayat/lokl/internal/config"
 )
 
+func TestCertPathChangesWithSANs(t *testing.T) {
+	c := newCertManager("/tmp")
+	a := c.certPath("test", []string{"*.test", "test"})
+	b := c.certPath("test", []string{"*.test", "test", "api.foo"})
+	if a == b {
+		t.Fatalf("cert path should differ when SANs differ; got %s == %s", a, b)
+	}
+	if c.keyPath("test", []string{"*.test", "test"}) == c.keyPath("test", []string{"*.test", "test", "api.foo"}) {
+		t.Fatal("key path should differ when SANs differ")
+	}
+	// Stable: same SANs in different order should produce same path.
+	c1 := c.certPath("test", []string{"a", "b", "c"})
+	c2 := c.certPath("test", []string{"c", "a", "b"})
+	if c1 != c2 {
+		t.Fatalf("cert path should be stable across SAN ordering; %s != %s", c1, c2)
+	}
+}
+
 func TestCertDomains(t *testing.T) {
 	t.Run("base domain only", func(t *testing.T) {
 		cfg := &config.Config{

--- a/internal/proxy/certs_test.go
+++ b/internal/proxy/certs_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shahin-bayat/lokl/internal/config"
+)
+
+func TestCertDomains(t *testing.T) {
+	t.Run("base domain only", func(t *testing.T) {
+		cfg := &config.Config{
+			Proxy: config.ProxyConfig{Domain: "test"},
+			Services: map[string]config.Service{
+				"a": {Port: 8000, Subdomains: config.Subdomains{"api"}},
+			},
+		}
+		p := New(cfg)
+		primary, sans := p.certDomains()
+		if primary != "test" {
+			t.Fatalf("primary=%q want test", primary)
+		}
+		want := []string{"*.test", "test", "api.test"}
+		if !reflect.DeepEqual(sans, want) {
+			t.Fatalf("sans=%v want %v", sans, want)
+		}
+	})
+
+	t.Run("wildcards outside proxy.Domain", func(t *testing.T) {
+		cfg := &config.Config{
+			Proxy: config.ProxyConfig{Domain: "test"},
+			Services: map[string]config.Service{
+				"w": {Port: 8000, Subdomains: config.Subdomains{"*.sellify.shop", "sellify.shop"}},
+			},
+		}
+		p := New(cfg)
+		primary, sans := p.certDomains()
+		if primary != "test" {
+			t.Fatalf("primary=%q want test", primary)
+		}
+		want := []string{"*.test", "test", "*.sellify.shop", "sellify.shop"}
+		if !reflect.DeepEqual(sans, want) {
+			t.Fatalf("sans=%v want %v", sans, want)
+		}
+	})
+
+	t.Run("no base domain, only wildcard", func(t *testing.T) {
+		cfg := &config.Config{
+			Services: map[string]config.Service{
+				"w": {Port: 8000, Subdomains: config.Subdomains{"*.sellify.shop"}},
+			},
+		}
+		p := New(cfg)
+		primary, sans := p.certDomains()
+		if primary != "sellify.shop" {
+			t.Fatalf("primary=%q want sellify.shop (first wildcard parent)", primary)
+		}
+		want := []string{"*.sellify.shop", "sellify.shop"}
+		if !reflect.DeepEqual(sans, want) {
+			t.Fatalf("sans=%v want %v", sans, want)
+		}
+	})
+}

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -144,12 +144,84 @@ func (d *dnsManager) MissingWildcardParents() []string {
 
 func (d *dnsManager) unresolved(domains []string) []string {
 	var missing []string
+
+	// Parse our hosts block once; used as the fallback oracle when LookupHost
+	// can't work (see coveredByInstalledWildcard).
+	blockHosts := d.currentBlockHosts()
+
 	for _, domain := range domains {
+		if d.coveredByInstalledWildcard(domain) {
+			if _, ok := blockHosts[domain]; ok {
+				continue
+			}
+			missing = append(missing, domain)
+			continue
+		}
 		if !d.resolvesToLocalhost(domain) {
 			missing = append(missing, domain)
 		}
 	}
 	return missing
+}
+
+// coveredByInstalledWildcard reports whether domain is under a wildcard parent
+// whose resolver file is installed. Such hosts cannot be probed via LookupHost
+// on macOS because the resolver file routes the whole zone to our DNS listener,
+// which is not running during pre-flight readiness checks.
+func (d *dnsManager) coveredByInstalledWildcard(domain string) bool {
+	if len(d.wildcardParents) == 0 || d.resolver == nil {
+		return false
+	}
+	missing := map[string]struct{}{}
+	for _, p := range d.resolver.Missing(d.wildcardParents) {
+		missing[p] = struct{}{}
+	}
+	for _, parent := range d.wildcardParents {
+		if _, isMissing := missing[parent]; isMissing {
+			continue
+		}
+		if domain == parent || strings.HasSuffix(domain, "."+parent) {
+			return true
+		}
+	}
+	return false
+}
+
+// currentBlockHosts returns the set of hostnames currently present in our
+// project's /etc/hosts block.
+func (d *dnsManager) currentBlockHosts() map[string]struct{} {
+	out := map[string]struct{}{}
+	content, err := os.ReadFile(d.hostsPathOrDefault())
+	if err != nil {
+		return out
+	}
+	startMarker := d.startMarker()
+	endMarker := d.endMarker()
+
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	inBlock := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == startMarker {
+			inBlock = true
+			continue
+		}
+		if line == endMarker {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		for _, host := range fields[1:] {
+			out[host] = struct{}{}
+		}
+	}
+	return out
 }
 
 func (d *dnsManager) resolvesToLocalhost(domain string) bool {

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -48,16 +48,22 @@ func (d *dnsManager) hostsPathOrDefault() string {
 }
 
 func (d *dnsManager) Setup(exactDomains []string) error {
+	// Install resolver files first — the riskier step — so a failure doesn't leave
+	// /etc/hosts partially mutated.
+	if len(d.wildcardParents) > 0 {
+		if err := d.resolver.Write(d.wildcardParents); err != nil {
+			return fmt.Errorf("writing resolver files: %w", err)
+		}
+	}
 	if err := d.add(exactDomains); err != nil {
+		if len(d.wildcardParents) > 0 {
+			_ = d.resolver.Remove(d.wildcardParents)
+		}
 		return err
 	}
-	if len(d.wildcardParents) == 0 {
-		return nil
+	if len(d.wildcardParents) > 0 {
+		_ = d.resolver.FlushCache()
 	}
-	if err := d.resolver.Write(d.wildcardParents); err != nil {
-		return fmt.Errorf("writing resolver files: %w", err)
-	}
-	_ = d.resolver.FlushCache()
 	return nil
 }
 

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -16,12 +16,61 @@ const (
 	dnsLookupTimeout = 2 * time.Second
 )
 
-type dnsManager struct {
-	project string
+type resolverWriter interface {
+	Write(parents []string) error
+	Remove(parents []string) error
+	FlushCache() error
 }
 
-func newDNSManager(project string) *dnsManager {
-	return &dnsManager{project: project}
+type dnsManager struct {
+	project         string
+	wildcardParents []string
+	resolver        resolverWriter
+	// hostsPath overrides the system hosts file in tests; empty means use hostsFile.
+	hostsPath string
+}
+
+func newDNSManager(project string, wildcardParents []string, dnsPort int) *dnsManager {
+	return &dnsManager{
+		project:         project,
+		wildcardParents: wildcardParents,
+		resolver:        newResolverDir(dnsPort),
+	}
+}
+
+func (d *dnsManager) hostsPathOrDefault() string {
+	if d.hostsPath != "" {
+		return d.hostsPath
+	}
+	return hostsFile
+}
+
+func (d *dnsManager) Setup(exactDomains []string) error {
+	if err := d.add(exactDomains); err != nil {
+		return err
+	}
+	if len(d.wildcardParents) == 0 {
+		return nil
+	}
+	if err := d.resolver.Write(d.wildcardParents); err != nil {
+		return fmt.Errorf("writing resolver files: %w", err)
+	}
+	_ = d.resolver.FlushCache()
+	return nil
+}
+
+func (d *dnsManager) Remove() error {
+	if err := d.remove(); err != nil {
+		return err
+	}
+	if len(d.wildcardParents) == 0 {
+		return nil
+	}
+	if err := d.resolver.Remove(d.wildcardParents); err != nil {
+		return fmt.Errorf("removing resolver files: %w", err)
+	}
+	_ = d.resolver.FlushCache()
+	return nil
 }
 
 func (d *dnsManager) add(domains []string) error {
@@ -29,7 +78,8 @@ func (d *dnsManager) add(domains []string) error {
 		return nil
 	}
 
-	content, err := os.ReadFile(hostsFile)
+	path := d.hostsPathOrDefault()
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("reading hosts file: %w", err)
 	}
@@ -45,7 +95,7 @@ func (d *dnsManager) add(domains []string) error {
 
 	newContent := strings.TrimRight(cleaned, "\n") + "\n\n" + block.String()
 
-	if err := os.WriteFile(hostsFile, []byte(newContent), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(newContent), 0o644); err != nil {
 		return fmt.Errorf("writing hosts file: %w", err)
 	}
 
@@ -53,14 +103,15 @@ func (d *dnsManager) add(domains []string) error {
 }
 
 func (d *dnsManager) remove() error {
-	content, err := os.ReadFile(hostsFile)
+	path := d.hostsPathOrDefault()
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("reading hosts file: %w", err)
 	}
 
 	cleaned := d.removeBlock(string(content))
 
-	if err := os.WriteFile(hostsFile, []byte(cleaned), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(cleaned), 0o644); err != nil {
 		return fmt.Errorf("writing hosts file: %w", err)
 	}
 
@@ -68,7 +119,7 @@ func (d *dnsManager) remove() error {
 }
 
 func (d *dnsManager) needsSudo() bool {
-	f, err := os.OpenFile(hostsFile, os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(d.hostsPathOrDefault(), os.O_WRONLY, 0o644)
 	if err != nil {
 		return true
 	}

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -20,6 +20,8 @@ type resolverWriter interface {
 	Write(parents []string) error
 	Remove(parents []string) error
 	FlushCache() error
+	// Missing returns the subset of parents that lack resolver installation.
+	Missing(parents []string) []string
 }
 
 type dnsManager struct {
@@ -125,6 +127,13 @@ func (d *dnsManager) needsSudo() bool {
 	}
 	_ = f.Close()
 	return false
+}
+
+func (d *dnsManager) MissingWildcardParents() []string {
+	if len(d.wildcardParents) == 0 {
+		return nil
+	}
+	return d.resolver.Missing(d.wildcardParents)
 }
 
 func (d *dnsManager) unresolved(domains []string) []string {

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -16,15 +16,15 @@ const (
 	dnsLookupTimeout = 2 * time.Second
 )
 
-type hostsManager struct {
+type dnsManager struct {
 	project string
 }
 
-func newHostsManager(project string) *hostsManager {
-	return &hostsManager{project: project}
+func newDNSManager(project string) *dnsManager {
+	return &dnsManager{project: project}
 }
 
-func (h *hostsManager) add(domains []string) error {
+func (d *dnsManager) add(domains []string) error {
 	if len(domains) == 0 {
 		return nil
 	}
@@ -34,14 +34,14 @@ func (h *hostsManager) add(domains []string) error {
 		return fmt.Errorf("reading hosts file: %w", err)
 	}
 
-	cleaned := h.removeBlock(string(content))
+	cleaned := d.removeBlock(string(content))
 
 	var block strings.Builder
-	block.WriteString(h.startMarker() + "\n")
+	block.WriteString(d.startMarker() + "\n")
 	for _, domain := range domains {
 		fmt.Fprintf(&block, "127.0.0.1 %s\n", domain)
 	}
-	block.WriteString(h.endMarker() + "\n")
+	block.WriteString(d.endMarker() + "\n")
 
 	newContent := strings.TrimRight(cleaned, "\n") + "\n\n" + block.String()
 
@@ -52,13 +52,13 @@ func (h *hostsManager) add(domains []string) error {
 	return nil
 }
 
-func (h *hostsManager) remove() error {
+func (d *dnsManager) remove() error {
 	content, err := os.ReadFile(hostsFile)
 	if err != nil {
 		return fmt.Errorf("reading hosts file: %w", err)
 	}
 
-	cleaned := h.removeBlock(string(content))
+	cleaned := d.removeBlock(string(content))
 
 	if err := os.WriteFile(hostsFile, []byte(cleaned), 0o644); err != nil {
 		return fmt.Errorf("writing hosts file: %w", err)
@@ -67,7 +67,7 @@ func (h *hostsManager) remove() error {
 	return nil
 }
 
-func (h *hostsManager) needsSudo() bool {
+func (d *dnsManager) needsSudo() bool {
 	f, err := os.OpenFile(hostsFile, os.O_WRONLY, 0o644)
 	if err != nil {
 		return true
@@ -76,17 +76,17 @@ func (h *hostsManager) needsSudo() bool {
 	return false
 }
 
-func (h *hostsManager) unresolved(domains []string) []string {
+func (d *dnsManager) unresolved(domains []string) []string {
 	var missing []string
 	for _, domain := range domains {
-		if !h.resolvesToLocalhost(domain) {
+		if !d.resolvesToLocalhost(domain) {
 			missing = append(missing, domain)
 		}
 	}
 	return missing
 }
 
-func (h *hostsManager) resolvesToLocalhost(domain string) bool {
+func (d *dnsManager) resolvesToLocalhost(domain string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
 	defer cancel()
 
@@ -98,27 +98,27 @@ func (h *hostsManager) resolvesToLocalhost(domain string) bool {
 	return slices.Contains(addrs, "127.0.0.1") || slices.Contains(addrs, "::1")
 }
 
-func (h *hostsManager) block(domains []string) string {
+func (d *dnsManager) block(domains []string) string {
 	var b strings.Builder
-	b.WriteString(h.startMarker() + "\n")
+	b.WriteString(d.startMarker() + "\n")
 	for _, domain := range domains {
 		fmt.Fprintf(&b, "127.0.0.1 %s\n", domain)
 	}
-	b.WriteString(h.endMarker())
+	b.WriteString(d.endMarker())
 	return b.String()
 }
 
-func (h *hostsManager) startMarker() string {
-	return fmt.Sprintf("# lokl:%s - START", h.project)
+func (d *dnsManager) startMarker() string {
+	return fmt.Sprintf("# lokl:%s - START", d.project)
 }
 
-func (h *hostsManager) endMarker() string {
-	return fmt.Sprintf("# lokl:%s - END", h.project)
+func (d *dnsManager) endMarker() string {
+	return fmt.Sprintf("# lokl:%s - END", d.project)
 }
 
-func (h *hostsManager) removeBlock(content string) string {
-	startMarker := h.startMarker()
-	endMarker := h.endMarker()
+func (d *dnsManager) removeBlock(content string) string {
+	startMarker := d.startMarker()
+	endMarker := d.endMarker()
 
 	var result strings.Builder
 	scanner := bufio.NewScanner(strings.NewReader(content))

--- a/internal/proxy/dns_server.go
+++ b/internal/proxy/dns_server.go
@@ -15,23 +15,30 @@ const (
 )
 
 type dnsServer struct {
-	addr     string
-	parents  []string
-	conn     *net.UDPConn
-	srv      *dns.Server
-	mu       sync.Mutex
-	errCh    chan error
-	closeErr sync.Once
+	addr    string
+	parents []string
+	conn    *net.UDPConn
+	srv     *dns.Server
+	mu      sync.Mutex
+	errCh   chan error
+	done    chan struct{}
 }
 
 func newDNSServer(addr string, parents []string) (*dnsServer, error) {
 	if len(parents) == 0 {
 		return nil, fmt.Errorf("dns server requires at least one wildcard parent")
 	}
-	return &dnsServer{addr: addr, parents: parents, errCh: make(chan error, 1)}, nil
+	return &dnsServer{
+		addr:    addr,
+		parents: parents,
+		errCh:   make(chan error, 1),
+		done:    make(chan struct{}),
+	}, nil
 }
 
-func (s *dnsServer) Start() error {
+func (s *dnsServer) Start() error { return s.startNotify(nil) }
+
+func (s *dnsServer) startNotify(started chan<- struct{}) error {
 	udpAddr, err := net.ResolveUDPAddr("udp", s.addr)
 	if err != nil {
 		return fmt.Errorf("resolving dns addr: %w", err)
@@ -43,14 +50,21 @@ func (s *dnsServer) Start() error {
 	s.mu.Lock()
 	s.conn = conn
 	s.srv = &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(s.handle)}
+	if started != nil {
+		s.srv.NotifyStartedFunc = func() { close(started) }
+	}
 	s.mu.Unlock()
 
 	go func() {
-		if err := s.srv.ActivateAndServe(); err != nil {
-			select {
-			case s.errCh <- err:
-			default:
-			}
+		err := s.srv.ActivateAndServe()
+		if err == nil {
+			return
+		}
+		// Drop the error if shutdown has started; avoids send-on-closed-channel panics.
+		select {
+		case <-s.done:
+		case s.errCh <- err:
+		default:
 		}
 	}()
 	return nil
@@ -65,9 +79,13 @@ func (s *dnsServer) Shutdown() error {
 	if srv == nil {
 		return nil
 	}
-	err := srv.Shutdown()
-	s.closeErr.Do(func() { close(s.errCh) })
-	return err
+	select {
+	case <-s.done:
+		return nil // already shut down
+	default:
+		close(s.done)
+	}
+	return srv.Shutdown()
 }
 
 func (s *dnsServer) LocalAddr() net.Addr {

--- a/internal/proxy/dns_server.go
+++ b/internal/proxy/dns_server.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	defaultDNSPort = 5454
+	dnsTTL         = 5
+)
+
+type dnsServer struct {
+	addr    string
+	parents []string
+	conn    *net.UDPConn
+	srv     *dns.Server
+	mu      sync.Mutex
+}
+
+func newDNSServer(addr string, parents []string) (*dnsServer, error) {
+	if len(parents) == 0 {
+		return nil, fmt.Errorf("dns server requires at least one wildcard parent")
+	}
+	return &dnsServer{addr: addr, parents: parents}, nil
+}
+
+func (s *dnsServer) Start() error {
+	udpAddr, err := net.ResolveUDPAddr("udp", s.addr)
+	if err != nil {
+		return fmt.Errorf("resolving dns addr: %w", err)
+	}
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", s.addr, err)
+	}
+	s.mu.Lock()
+	s.conn = conn
+	s.srv = &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(s.handle)}
+	s.mu.Unlock()
+
+	go func() { _ = s.srv.ActivateAndServe() }()
+	return nil
+}
+
+func (s *dnsServer) Shutdown() error {
+	s.mu.Lock()
+	srv := s.srv
+	s.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown()
+}
+
+func (s *dnsServer) LocalAddr() net.Addr {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.LocalAddr()
+}
+
+func (s *dnsServer) handle(w dns.ResponseWriter, req *dns.Msg) {
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Authoritative = true
+
+	if len(req.Question) != 1 {
+		resp.Rcode = dns.RcodeRefused
+		_ = w.WriteMsg(resp)
+		return
+	}
+
+	q := req.Question[0]
+	name := strings.TrimSuffix(strings.ToLower(q.Name), ".")
+	if !s.inScope(name) {
+		resp.Rcode = dns.RcodeRefused
+		_ = w.WriteMsg(resp)
+		return
+	}
+
+	hdr := dns.RR_Header{Name: q.Name, Class: dns.ClassINET, Ttl: dnsTTL}
+	switch q.Qtype {
+	case dns.TypeA:
+		hdr.Rrtype = dns.TypeA
+		resp.Answer = append(resp.Answer, &dns.A{Hdr: hdr, A: net.IPv4(127, 0, 0, 1)})
+	case dns.TypeAAAA:
+		hdr.Rrtype = dns.TypeAAAA
+		resp.Answer = append(resp.Answer, &dns.AAAA{Hdr: hdr, AAAA: net.ParseIP("::1")})
+	}
+	_ = w.WriteMsg(resp)
+}
+
+// inScope reports whether name equals a known parent or is one of its subdomains.
+func (s *dnsServer) inScope(name string) bool {
+	for _, parent := range s.parents {
+		if name == parent {
+			return true
+		}
+		if strings.HasSuffix(name, "."+parent) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/proxy/dns_server.go
+++ b/internal/proxy/dns_server.go
@@ -110,11 +110,14 @@ func (s *dnsServer) handle(w dns.ResponseWriter, req *dns.Msg) {
 	_ = w.WriteMsg(resp)
 }
 
-// inScope reports whether name equals a known parent or is one of its subdomains.
+// inScope reports whether name is a subdomain of a known wildcard parent.
+// The bare parent (apex) is intentionally refused: apex hosts are served via
+// /etc/hosts when explicitly declared, and answering the apex here would steal
+// traffic meant for the real domain when only wildcards are declared.
 func (s *dnsServer) inScope(name string) bool {
 	for _, parent := range s.parents {
 		if name == parent {
-			return true
+			continue
 		}
 		if strings.HasSuffix(name, "."+parent) {
 			return true

--- a/internal/proxy/dns_server.go
+++ b/internal/proxy/dns_server.go
@@ -15,18 +15,20 @@ const (
 )
 
 type dnsServer struct {
-	addr    string
-	parents []string
-	conn    *net.UDPConn
-	srv     *dns.Server
-	mu      sync.Mutex
+	addr     string
+	parents  []string
+	conn     *net.UDPConn
+	srv      *dns.Server
+	mu       sync.Mutex
+	errCh    chan error
+	closeErr sync.Once
 }
 
 func newDNSServer(addr string, parents []string) (*dnsServer, error) {
 	if len(parents) == 0 {
 		return nil, fmt.Errorf("dns server requires at least one wildcard parent")
 	}
-	return &dnsServer{addr: addr, parents: parents}, nil
+	return &dnsServer{addr: addr, parents: parents, errCh: make(chan error, 1)}, nil
 }
 
 func (s *dnsServer) Start() error {
@@ -43,9 +45,18 @@ func (s *dnsServer) Start() error {
 	s.srv = &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(s.handle)}
 	s.mu.Unlock()
 
-	go func() { _ = s.srv.ActivateAndServe() }()
+	go func() {
+		if err := s.srv.ActivateAndServe(); err != nil {
+			select {
+			case s.errCh <- err:
+			default:
+			}
+		}
+	}()
 	return nil
 }
+
+func (s *dnsServer) Err() <-chan error { return s.errCh }
 
 func (s *dnsServer) Shutdown() error {
 	s.mu.Lock()
@@ -54,7 +65,9 @@ func (s *dnsServer) Shutdown() error {
 	if srv == nil {
 		return nil
 	}
-	return srv.Shutdown()
+	err := srv.Shutdown()
+	s.closeErr.Do(func() { close(s.errCh) })
+	return err
 }
 
 func (s *dnsServer) LocalAddr() net.Addr {

--- a/internal/proxy/dns_server_test.go
+++ b/internal/proxy/dns_server_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestDNSServerAnswers(t *testing.T) {
+	srv, addr := startTestDNSServer(t, []string{"sellify.shop"})
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	tests := []struct {
+		name string
+		q    string
+		qt   uint16
+		rc   int
+		ip   string
+	}{
+		{"A in scope", "x.sellify.shop.", dns.TypeA, dns.RcodeSuccess, "127.0.0.1"},
+		{"AAAA in scope", "x.sellify.shop.", dns.TypeAAAA, dns.RcodeSuccess, "::1"},
+		{"out of scope", "other.test.", dns.TypeA, dns.RcodeRefused, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetQuestion(tc.q, tc.qt)
+			c := &dns.Client{Net: "udp", Timeout: 500 * time.Millisecond}
+			resp, _, err := c.Exchange(m, addr)
+			if err != nil {
+				t.Fatalf("exchange: %v", err)
+			}
+			if resp.Rcode != tc.rc {
+				t.Fatalf("rcode=%d want %d", resp.Rcode, tc.rc)
+			}
+			if tc.ip == "" {
+				return
+			}
+			if len(resp.Answer) == 0 {
+				t.Fatal("no answer records")
+			}
+			switch rr := resp.Answer[0].(type) {
+			case *dns.A:
+				if rr.A.String() != tc.ip {
+					t.Fatalf("A=%s want %s", rr.A, tc.ip)
+				}
+			case *dns.AAAA:
+				if rr.AAAA.String() != tc.ip {
+					t.Fatalf("AAAA=%s want %s", rr.AAAA, tc.ip)
+				}
+			default:
+				t.Fatalf("unexpected answer type %T", rr)
+			}
+		})
+	}
+}
+
+func startTestDNSServer(t *testing.T, parents []string) (*dnsServer, string) {
+	t.Helper()
+	srv, err := newDNSServer("127.0.0.1:0", parents)
+	if err != nil {
+		t.Fatalf("new dns server: %v", err)
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	for i := 0; i < 50 && srv.LocalAddr() == nil; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.LocalAddr() == nil {
+		t.Fatal("server did not bind in time")
+	}
+	return srv, srv.LocalAddr().String()
+}

--- a/internal/proxy/dns_server_test.go
+++ b/internal/proxy/dns_server_test.go
@@ -72,14 +72,30 @@ func TestDNSServerRefusesParentApex(t *testing.T) {
 	}
 }
 
+func TestDNSServerShutdownNoPanic(t *testing.T) {
+	srv, _ := startTestDNSServer(t, []string{"x.test"})
+	if err := srv.Shutdown(); err != nil {
+		t.Fatalf("first shutdown: %v", err)
+	}
+	if err := srv.Shutdown(); err != nil {
+		t.Fatalf("second shutdown should be idempotent: %v", err)
+	}
+}
+
 func startTestDNSServer(t *testing.T, parents []string) (*dnsServer, string) {
 	t.Helper()
 	srv, err := newDNSServer("127.0.0.1:0", parents)
 	if err != nil {
 		t.Fatalf("new dns server: %v", err)
 	}
-	if err := srv.Start(); err != nil {
+	started := make(chan struct{})
+	if err := srv.startNotify(started); err != nil {
 		t.Fatalf("start: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dns server did not start in time")
 	}
 	addr := srv.LocalAddr()
 	if addr == nil {

--- a/internal/proxy/dns_server_test.go
+++ b/internal/proxy/dns_server_test.go
@@ -65,11 +65,9 @@ func startTestDNSServer(t *testing.T, parents []string) (*dnsServer, string) {
 	if err := srv.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	for i := 0; i < 50 && srv.LocalAddr() == nil; i++ {
-		time.Sleep(10 * time.Millisecond)
+	addr := srv.LocalAddr()
+	if addr == nil {
+		t.Fatal("listener did not bind")
 	}
-	if srv.LocalAddr() == nil {
-		t.Fatal("server did not bind in time")
-	}
-	return srv, srv.LocalAddr().String()
+	return srv, addr.String()
 }

--- a/internal/proxy/dns_server_test.go
+++ b/internal/proxy/dns_server_test.go
@@ -56,6 +56,22 @@ func TestDNSServerAnswers(t *testing.T) {
 	}
 }
 
+func TestDNSServerRefusesParentApex(t *testing.T) {
+	srv, addr := startTestDNSServer(t, []string{"sellify.shop"})
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	m := new(dns.Msg)
+	m.SetQuestion("sellify.shop.", dns.TypeA)
+	c := &dns.Client{Net: "udp", Timeout: 500 * time.Millisecond}
+	resp, _, err := c.Exchange(m, addr)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if resp.Rcode != dns.RcodeRefused {
+		t.Fatalf("apex must be REFUSED, got rcode=%d", resp.Rcode)
+	}
+}
+
 func startTestDNSServer(t *testing.T, parents []string) (*dnsServer, string) {
 	t.Helper()
 	srv, err := newDNSServer("127.0.0.1:0", parents)

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -11,6 +11,7 @@ type fakeResolver struct {
 	written [][]string
 	removed [][]string
 	flushed int
+	missing []string
 }
 
 func (f *fakeResolver) Write(p []string) error {
@@ -22,6 +23,18 @@ func (f *fakeResolver) Remove(p []string) error {
 	return nil
 }
 func (f *fakeResolver) FlushCache() error { f.flushed++; return nil }
+func (f *fakeResolver) Missing(parents []string) []string {
+	var out []string
+	for _, p := range parents {
+		for _, m := range f.missing {
+			if p == m {
+				out = append(out, p)
+				break
+			}
+		}
+	}
+	return out
+}
 
 func TestDNSManagerSetupWritesResolverFiles(t *testing.T) {
 	tmp := t.TempDir()
@@ -74,6 +87,27 @@ func TestDNSManagerSetupSkipsResolverWithoutWildcards(t *testing.T) {
 	}
 	if len(fr.written) != 0 || fr.flushed != 0 {
 		t.Fatalf("resolver should be untouched when no wildcards; writes=%v flushed=%d", fr.written, fr.flushed)
+	}
+}
+
+func TestUnresolvedReportsMissingWildcardParents(t *testing.T) {
+	fr := &fakeResolver{missing: []string{"sellify.shop"}}
+	d := &dnsManager{
+		project:         "demo",
+		wildcardParents: []string{"sellify.shop"},
+		resolver:        fr,
+	}
+	got := d.MissingWildcardParents()
+	if len(got) != 1 || got[0] != "sellify.shop" {
+		t.Fatalf("got=%v want [sellify.shop]", got)
+	}
+}
+
+func TestMissingWildcardParentsEmptyWithoutWildcards(t *testing.T) {
+	fr := &fakeResolver{}
+	d := &dnsManager{project: "demo", resolver: fr}
+	if got := d.MissingWildcardParents(); len(got) != 0 {
+		t.Fatalf("got=%v want nil", got)
 	}
 }
 

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -108,6 +109,31 @@ func TestMissingWildcardParentsEmptyWithoutWildcards(t *testing.T) {
 	d := &dnsManager{project: "demo", resolver: fr}
 	if got := d.MissingWildcardParents(); len(got) != 0 {
 		t.Fatalf("got=%v want nil", got)
+	}
+}
+
+type failingResolver struct{ fakeResolver }
+
+func (f *failingResolver) Write(p []string) error { return errors.New("boom") }
+
+func TestSetupDoesNotWriteHostsWhenResolverFails(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	if err := os.WriteFile(hostsPath, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &dnsManager{
+		project:         "demo",
+		hostsPath:       hostsPath,
+		resolver:        &failingResolver{},
+		wildcardParents: []string{"sellify.shop"},
+	}
+	if err := d.Setup([]string{"api.test"}); err == nil {
+		t.Fatal("Setup must error when resolver fails")
+	}
+	b, _ := os.ReadFile(hostsPath)
+	if string(b) != "original\n" {
+		t.Fatalf("hosts should be untouched when resolver fails; got %q", b)
 	}
 }
 

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -3,7 +3,7 @@ package proxy
 import "testing"
 
 func TestHostsManagerRemoveBlock(t *testing.T) {
-	h := newHostsManager("myproject")
+	h := newDNSManager("myproject")
 
 	tests := []struct {
 		name    string
@@ -76,7 +76,7 @@ func TestHostsManagerRemoveBlock(t *testing.T) {
 }
 
 func TestHostsManagerBlock(t *testing.T) {
-	h := newHostsManager("myproject")
+	h := newDNSManager("myproject")
 
 	got := h.block([]string{"app.example.com", "api.example.com"})
 
@@ -91,7 +91,7 @@ func TestHostsManagerBlock(t *testing.T) {
 }
 
 func TestHostsManagerBlockEmpty(t *testing.T) {
-	h := newHostsManager("myproject")
+	h := newDNSManager("myproject")
 
 	got := h.block(nil)
 	want := "# lokl:myproject - START\n# lokl:myproject - END"
@@ -102,7 +102,7 @@ func TestHostsManagerBlockEmpty(t *testing.T) {
 }
 
 func TestHostsManagerMarkers(t *testing.T) {
-	h := newHostsManager("testproject")
+	h := newDNSManager("testproject")
 
 	if h.startMarker() != "# lokl:testproject - START" {
 		t.Errorf("startMarker() = %q", h.startMarker())

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -137,6 +137,47 @@ func TestSetupDoesNotWriteHostsWhenResolverFails(t *testing.T) {
 	}
 }
 
+func TestUnresolvedTrustsHostsBlockWhenWildcardResolverInstalled(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	seed := `# lokl:demo - START
+127.0.0.1 sellify.shop
+127.0.0.1 s3.sellify.shop
+# lokl:demo - END
+`
+	if err := os.WriteFile(hostsPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &dnsManager{
+		project:         "demo",
+		hostsPath:       hostsPath,
+		wildcardParents: []string{"sellify.shop"},
+		resolver:        &fakeResolver{missing: nil},
+	}
+	got := d.unresolved([]string{"sellify.shop", "s3.sellify.shop"})
+	if len(got) != 0 {
+		t.Fatalf("unresolved should be empty when hosts block has entries and resolver installed; got %v", got)
+	}
+}
+
+func TestUnresolvedReportsHostsMissingUnderInstalledWildcard(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	if err := os.WriteFile(hostsPath, []byte("# lokl:demo - START\n# lokl:demo - END\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &dnsManager{
+		project:         "demo",
+		hostsPath:       hostsPath,
+		wildcardParents: []string{"sellify.shop"},
+		resolver:        &fakeResolver{missing: nil},
+	}
+	got := d.unresolved([]string{"sellify.shop"})
+	if len(got) != 1 || got[0] != "sellify.shop" {
+		t.Fatalf("want [sellify.shop], got %v", got)
+	}
+}
+
 func TestHostsManagerRemoveBlock(t *testing.T) {
 	h := newDNSManager("myproject", nil, 0)
 

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -1,9 +1,84 @@
 package proxy
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+type fakeResolver struct {
+	written [][]string
+	removed [][]string
+	flushed int
+}
+
+func (f *fakeResolver) Write(p []string) error {
+	f.written = append(f.written, append([]string(nil), p...))
+	return nil
+}
+func (f *fakeResolver) Remove(p []string) error {
+	f.removed = append(f.removed, append([]string(nil), p...))
+	return nil
+}
+func (f *fakeResolver) FlushCache() error { f.flushed++; return nil }
+
+func TestDNSManagerSetupWritesResolverFiles(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	if err := os.WriteFile(hostsPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fr := &fakeResolver{}
+	d := &dnsManager{
+		project:         "demo",
+		hostsPath:       hostsPath,
+		resolver:        fr,
+		wildcardParents: []string{"sellify.shop"},
+	}
+	if err := d.Setup([]string{"api.sellify.shop"}); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if len(fr.written) != 1 || !slices.Equal(fr.written[0], []string{"sellify.shop"}) {
+		t.Fatalf("resolver writes=%v", fr.written)
+	}
+	if fr.flushed != 1 {
+		t.Fatalf("flushed=%d want 1", fr.flushed)
+	}
+
+	if err := d.Remove(); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(fr.removed) != 1 || !slices.Equal(fr.removed[0], []string{"sellify.shop"}) {
+		t.Fatalf("resolver removes=%v", fr.removed)
+	}
+	if fr.flushed != 2 {
+		t.Fatalf("flushed=%d want 2", fr.flushed)
+	}
+}
+
+func TestDNSManagerSetupSkipsResolverWithoutWildcards(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	if err := os.WriteFile(hostsPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fr := &fakeResolver{}
+	d := &dnsManager{
+		project:   "demo",
+		hostsPath: hostsPath,
+		resolver:  fr,
+	}
+	if err := d.Setup([]string{"a.test"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fr.written) != 0 || fr.flushed != 0 {
+		t.Fatalf("resolver should be untouched when no wildcards; writes=%v flushed=%d", fr.written, fr.flushed)
+	}
+}
 
 func TestHostsManagerRemoveBlock(t *testing.T) {
-	h := newDNSManager("myproject")
+	h := newDNSManager("myproject", nil, 0)
 
 	tests := []struct {
 		name    string
@@ -76,7 +151,7 @@ func TestHostsManagerRemoveBlock(t *testing.T) {
 }
 
 func TestHostsManagerBlock(t *testing.T) {
-	h := newDNSManager("myproject")
+	h := newDNSManager("myproject", nil, 0)
 
 	got := h.block([]string{"app.example.com", "api.example.com"})
 
@@ -91,7 +166,7 @@ func TestHostsManagerBlock(t *testing.T) {
 }
 
 func TestHostsManagerBlockEmpty(t *testing.T) {
-	h := newDNSManager("myproject")
+	h := newDNSManager("myproject", nil, 0)
 
 	got := h.block(nil)
 	want := "# lokl:myproject - START\n# lokl:myproject - END"
@@ -102,7 +177,7 @@ func TestHostsManagerBlockEmpty(t *testing.T) {
 }
 
 func TestHostsManagerMarkers(t *testing.T) {
-	h := newDNSManager("testproject")
+	h := newDNSManager("testproject", nil, 0)
 
 	if h.startMarker() != "# lokl:testproject - START" {
 		t.Errorf("startMarker() = %q", h.startMarker())

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -102,11 +102,25 @@ func (h *handler) selectTarget(rt *route, r *http.Request) (target *url.URL, tra
 		return &url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", rt.port)}, nil, false, nil
 	}
 
-	transport, err = h.remoteTransport(rt.domain)
+	host := remoteHost(rt, r.Host)
+	transport, err = h.remoteTransport(host)
 	if err != nil {
 		return nil, nil, false, err
 	}
-	return &url.URL{Scheme: "https", Host: rt.domain}, transport, true, nil
+	return &url.URL{Scheme: "https", Host: host}, transport, true, nil
+}
+
+// remoteHost picks the host to dial for disabled (remote-fallback) routes.
+// For wildcards, rt.domain is a pattern (*.parent); use the concrete request
+// host instead so DNS resolution and SNI target a real name.
+func remoteHost(rt *route, reqHost string) string {
+	if rt.parent == "" {
+		return rt.domain
+	}
+	if idx := strings.LastIndex(reqHost, ":"); idx != -1 {
+		reqHost = reqHost[:idx]
+	}
+	return reqHost
 }
 
 // resolveViaDNS queries external DNS directly, bypassing /etc/hosts

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -94,6 +94,18 @@ func (h *handler) invalidateCache(domain string) {
 	h.dnsMu.Unlock()
 }
 
+// invalidateCacheSuffix clears every cached host equal to parent or under it.
+// Wildcard routes cache by concrete request host, so exact-key invalidation misses them.
+func (h *handler) invalidateCacheSuffix(parent string) {
+	h.dnsMu.Lock()
+	defer h.dnsMu.Unlock()
+	for host := range h.dnsCache {
+		if host == parent || strings.HasSuffix(host, "."+parent) {
+			delete(h.dnsCache, host)
+		}
+	}
+}
+
 func (h *handler) selectTarget(rt *route, r *http.Request) (target *url.URL, transport http.RoundTripper, remote bool, err error) {
 	if rt.enabled.Load() {
 		if rt.rewrite != nil {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -253,6 +253,21 @@ func TestHasFileExtension(t *testing.T) {
 	}
 }
 
+func TestRemoteHost(t *testing.T) {
+	exact := &route{domain: "app.sellify.shop"}
+	wild := &route{domain: "*.sellify.shop", parent: "sellify.shop"}
+
+	if got := remoteHost(exact, "app.sellify.shop"); got != "app.sellify.shop" {
+		t.Errorf("exact: got %q want app.sellify.shop", got)
+	}
+	if got := remoteHost(wild, "acme.sellify.shop"); got != "acme.sellify.shop" {
+		t.Errorf("wildcard: got %q want acme.sellify.shop (not pattern)", got)
+	}
+	if got := remoteHost(wild, "acme.sellify.shop:8443"); got != "acme.sellify.shop" {
+		t.Errorf("wildcard with port: got %q want acme.sellify.shop", got)
+	}
+}
+
 func TestSelectTargetUsesIPv4Loopback(t *testing.T) {
 	rt := &route{port: 3000}
 	rt.enabled.Store(true)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -268,6 +268,25 @@ func TestRemoteHost(t *testing.T) {
 	}
 }
 
+func TestInvalidateCacheSuffix(t *testing.T) {
+	h := newHandler(nil)
+	h.dnsCache["acme.sellify.shop"] = "1.2.3.4"
+	h.dnsCache["sellify.shop"] = "5.6.7.8"
+	h.dnsCache["other.test"] = "9.9.9.9"
+
+	h.invalidateCacheSuffix("sellify.shop")
+
+	if _, ok := h.dnsCache["acme.sellify.shop"]; ok {
+		t.Fatal("acme.sellify.shop should be evicted")
+	}
+	if _, ok := h.dnsCache["sellify.shop"]; ok {
+		t.Fatal("sellify.shop should be evicted")
+	}
+	if _, ok := h.dnsCache["other.test"]; !ok {
+		t.Fatal("other.test should remain")
+	}
+}
+
 func TestSelectTargetUsesIPv4Loopback(t *testing.T) {
 	rt := &route{port: 3000}
 	rt.enabled.Store(true)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -113,7 +113,7 @@ func TestHandlerServeHTTPLocalRoute(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "t.example.com"},
 		Services: map[string]config.Service{
-			"web": {Subdomain: "app", Port: port},
+			"web": {Subdomains: config.Subdomains{"app"}, Port: port},
 		},
 	}
 
@@ -165,7 +165,7 @@ func TestHandlerXForwardedHeaders(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "t.example.com"},
 		Services: map[string]config.Service{
-			"web": {Subdomain: "app", Port: port},
+			"web": {Subdomains: config.Subdomains{"app"}, Port: port},
 		},
 	}
 
@@ -198,7 +198,7 @@ func TestHandlerResponseHeaders(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "t.example.com"},
 		Services: map[string]config.Service{
-			"web": {Subdomain: "app", Port: port},
+			"web": {Subdomains: config.Subdomains{"app"}, Port: port},
 		},
 	}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/shahin-bayat/lokl/internal/config"
@@ -22,24 +23,51 @@ const (
 )
 
 type Proxy struct {
-	cfg     *config.Config
-	router  *router
-	certs   *certManager
-	hosts   *hostsManager
-	handler *handler
-	server  *http.Server
-	port    int
+	cfg             *config.Config
+	router          *router
+	certs           *certManager
+	hosts           *hostsManager
+	handler         *handler
+	server          *http.Server
+	port            int
+	hasWildcard     bool
+	wildcardParents []string
+	dnsPort         int
+	dns             *dnsServer
+}
+
+func collectWildcardParents(cfg *config.Config) []string {
+	seen := map[string]struct{}{}
+	var parents []string
+	for _, svc := range cfg.Services {
+		for _, sd := range svc.Subdomains {
+			after, ok := strings.CutPrefix(sd, "*.")
+			if !ok {
+				continue
+			}
+			if _, dup := seen[after]; dup {
+				continue
+			}
+			seen[after] = struct{}{}
+			parents = append(parents, after)
+		}
+	}
+	return parents
 }
 
 func New(cfg *config.Config) *Proxy {
 	r := newRouter(cfg)
+	parents := collectWildcardParents(cfg)
 	return &Proxy{
-		cfg:     cfg,
-		router:  r,
-		certs:   newCertManager(defaultCertDir),
-		hosts:   newHostsManager(cfg.Name),
-		handler: newHandler(r),
-		port:    defaultPort,
+		cfg:             cfg,
+		router:          r,
+		certs:           newCertManager(defaultCertDir),
+		hosts:           newHostsManager(cfg.Name),
+		handler:         newHandler(r),
+		port:            defaultPort,
+		hasWildcard:     len(parents) > 0,
+		wildcardParents: parents,
+		dnsPort:         defaultDNSPort,
 	}
 }
 
@@ -86,6 +114,17 @@ func (p *Proxy) Start() error {
 		}
 	}()
 
+	if p.hasWildcard {
+		srv, err := newDNSServer(fmt.Sprintf("127.0.0.1:%d", p.dnsPort), p.wildcardParents)
+		if err != nil {
+			return fmt.Errorf("dns server: %w", err)
+		}
+		if err := srv.Start(); err != nil {
+			return fmt.Errorf("dns server on 127.0.0.1:%d (set proxy.dns_port to override): %w", p.dnsPort, err)
+		}
+		p.dns = srv
+	}
+
 	return nil
 }
 
@@ -99,6 +138,13 @@ func (p *Proxy) Stop(cleanupDNS bool) error {
 		if err := p.server.Shutdown(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("shutting down server: %w", err))
 		}
+	}
+
+	if p.dns != nil {
+		if err := p.dns.Shutdown(); err != nil {
+			errs = append(errs, fmt.Errorf("shutting down dns server: %w", err))
+		}
+		p.dns = nil
 	}
 
 	if cleanupDNS {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -26,7 +26,7 @@ type Proxy struct {
 	cfg             *config.Config
 	router          *router
 	certs           *certManager
-	hosts           *hostsManager
+	sysDNS          *dnsManager
 	handler         *handler
 	server          *http.Server
 	port            int
@@ -43,7 +43,7 @@ func New(cfg *config.Config) *Proxy {
 		cfg:             cfg,
 		router:          r,
 		certs:           newCertManager(defaultCertDir),
-		hosts:           newHostsManager(cfg.Name),
+		sysDNS:          newDNSManager(cfg.Name),
 		handler:         newHandler(r),
 		port:            defaultPort,
 		hasWildcard:     len(parents) > 0,
@@ -153,7 +153,7 @@ func (p *Proxy) Stop(cleanupDNS bool) error {
 	}
 
 	if cleanupDNS {
-		if err := p.hosts.remove(); err != nil {
+		if err := p.sysDNS.remove(); err != nil {
 			errs = append(errs, fmt.Errorf("removing DNS entries: %w", err))
 		}
 	}
@@ -180,23 +180,23 @@ func (p *Proxy) CertDir() string {
 }
 
 func (p *Proxy) NeedsSudo() bool {
-	return p.hosts.needsSudo()
+	return p.sysDNS.needsSudo()
 }
 
 func (p *Proxy) UnresolvedDomains() []string {
-	return p.hosts.unresolved(p.router.enabledDomains())
+	return p.sysDNS.unresolved(p.router.enabledDomains())
 }
 
 func (p *Proxy) DNSBlock() string {
-	return p.hosts.block(p.router.enabledDomains())
+	return p.sysDNS.block(p.router.enabledDomains())
 }
 
 func (p *Proxy) SetupDNS() error {
-	return p.hosts.add(p.router.enabledDomains())
+	return p.sysDNS.add(p.router.enabledDomains())
 }
 
 func (p *Proxy) RemoveDNS() error {
-	return p.hosts.remove()
+	return p.sysDNS.remove()
 }
 
 func (p *Proxy) EnableServiceProxy(name string) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -43,7 +43,7 @@ func New(cfg *config.Config) *Proxy {
 		cfg:             cfg,
 		router:          r,
 		certs:           newCertManager(defaultCertDir),
-		sysDNS:          newDNSManager(cfg.Name),
+		sysDNS:          newDNSManager(cfg.Name, parents, defaultDNSPort),
 		handler:         newHandler(r),
 		port:            defaultPort,
 		hasWildcard:     len(parents) > 0,
@@ -153,7 +153,7 @@ func (p *Proxy) Stop(cleanupDNS bool) error {
 	}
 
 	if cleanupDNS {
-		if err := p.sysDNS.remove(); err != nil {
+		if err := p.sysDNS.Remove(); err != nil {
 			errs = append(errs, fmt.Errorf("removing DNS entries: %w", err))
 		}
 	}
@@ -192,11 +192,15 @@ func (p *Proxy) DNSBlock() string {
 }
 
 func (p *Proxy) SetupDNS() error {
-	return p.sysDNS.add(p.router.enabledDomains())
+	return p.sysDNS.Setup(p.router.enabledDomains())
 }
 
 func (p *Proxy) RemoveDNS() error {
-	return p.sysDNS.remove()
+	return p.sysDNS.Remove()
+}
+
+func (p *Proxy) WildcardParentCount() int {
+	return len(p.wildcardParents)
 }
 
 func (p *Proxy) EnableServiceProxy(name string) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -108,8 +108,8 @@ func (p *Proxy) Start() error {
 		return fmt.Errorf("binding port %d: %w", p.port, err)
 	}
 
-	primary, _ := p.certDomains()
-	cert, err := tls.LoadX509KeyPair(p.certs.certPath(primary), p.certs.keyPath(primary))
+	primary, sans := p.certDomains()
+	cert, err := tls.LoadX509KeyPair(p.certs.certPath(primary, sans), p.certs.keyPath(primary, sans))
 	if err != nil {
 		_ = ln.Close()
 		return fmt.Errorf("loading certificate: %w", err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -108,11 +108,8 @@ func (p *Proxy) Start() error {
 		return fmt.Errorf("binding port %d: %w", p.port, err)
 	}
 
-	domain := p.router.domain()
-	if domain == "" && len(p.wildcardParents) > 0 {
-		domain = p.wildcardParents[0]
-	}
-	cert, err := tls.LoadX509KeyPair(p.certs.certPath(domain), p.certs.keyPath(domain))
+	primary, _ := p.certDomains()
+	cert, err := tls.LoadX509KeyPair(p.certs.certPath(primary), p.certs.keyPath(primary))
 	if err != nil {
 		_ = ln.Close()
 		return fmt.Errorf("loading certificate: %w", err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -217,7 +217,11 @@ func (p *Proxy) NeedsSudo() bool {
 }
 
 func (p *Proxy) UnresolvedDomains() []string {
-	return p.sysDNS.unresolved(p.router.enabledDomains())
+	missing := p.sysDNS.unresolved(p.router.enabledDomains())
+	for _, parent := range p.sysDNS.MissingWildcardParents() {
+		missing = append(missing, "*."+parent)
+	}
+	return missing
 }
 
 func (p *Proxy) DNSBlock() string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -53,8 +53,8 @@ func New(cfg *config.Config) *Proxy {
 }
 
 func (p *Proxy) Setup() error {
-	domain := p.router.domain()
-	if domain == "" {
+	primary, sans := p.certDomains()
+	if primary == "" {
 		return fmt.Errorf("no proxy domain configured")
 	}
 
@@ -62,11 +62,44 @@ func (p *Proxy) Setup() error {
 		return fmt.Errorf("setting up CA: %w", err)
 	}
 
-	if _, _, err := p.certs.generate(domain); err != nil {
+	if _, _, err := p.certs.generate(primary, sans); err != nil {
 		return fmt.Errorf("generating certificate: %w", err)
 	}
 
 	return nil
+}
+
+// certDomains returns the primary cert name and the full SAN list, deduped and ordered
+// so base-domain-only configs produce the same output as before wildcard support.
+func (p *Proxy) certDomains() (string, []string) {
+	primary := p.router.domain()
+	seen := map[string]struct{}{}
+	var sans []string
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		sans = append(sans, s)
+	}
+	if primary != "" {
+		add("*." + primary)
+		add(primary)
+	}
+	for _, parent := range p.wildcardParents {
+		add("*." + parent)
+		add(parent)
+	}
+	for _, d := range p.router.domains() {
+		add(d)
+	}
+	if primary == "" && len(p.wildcardParents) > 0 {
+		primary = p.wildcardParents[0]
+	}
+	return primary, sans
 }
 
 func (p *Proxy) Start() error {
@@ -76,6 +109,9 @@ func (p *Proxy) Start() error {
 	}
 
 	domain := p.router.domain()
+	if domain == "" && len(p.wildcardParents) > 0 {
+		domain = p.wildcardParents[0]
+	}
 	cert, err := tls.LoadX509KeyPair(p.certs.certPath(domain), p.certs.keyPath(domain))
 	if err != nil {
 		_ = ln.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -36,25 +36,6 @@ type Proxy struct {
 	dns             *dnsServer
 }
 
-func collectWildcardParents(cfg *config.Config) []string {
-	seen := map[string]struct{}{}
-	var parents []string
-	for _, svc := range cfg.Services {
-		for _, sd := range svc.Subdomains {
-			after, ok := strings.CutPrefix(sd, "*.")
-			if !ok {
-				continue
-			}
-			if _, dup := seen[after]; dup {
-				continue
-			}
-			seen[after] = struct{}{}
-			parents = append(parents, after)
-		}
-	}
-	return parents
-}
-
 func New(cfg *config.Config) *Proxy {
 	r := newRouter(cfg)
 	parents := collectWildcardParents(cfg)
@@ -117,15 +98,39 @@ func (p *Proxy) Start() error {
 	if p.hasWildcard {
 		srv, err := newDNSServer(fmt.Sprintf("127.0.0.1:%d", p.dnsPort), p.wildcardParents)
 		if err != nil {
+			_ = p.server.Shutdown(context.Background())
+			p.server = nil
 			return fmt.Errorf("dns server: %w", err)
 		}
 		if err := srv.Start(); err != nil {
-			return fmt.Errorf("dns server on 127.0.0.1:%d (set proxy.dns_port to override): %w", p.dnsPort, err)
+			_ = p.server.Shutdown(context.Background())
+			p.server = nil
+			return fmt.Errorf("dns server on 127.0.0.1:%d: %w", p.dnsPort, err)
 		}
+		// TODO: surface p.dns.Err() to the supervisor so runtime DNS failures are visible.
 		p.dns = srv
 	}
 
 	return nil
+}
+
+func collectWildcardParents(cfg *config.Config) []string {
+	seen := map[string]struct{}{}
+	var parents []string
+	for _, svc := range cfg.Services {
+		for _, sd := range svc.Subdomains {
+			after, ok := strings.CutPrefix(sd, "*.")
+			if !ok {
+				continue
+			}
+			if _, dup := seen[after]; dup {
+				continue
+			}
+			seen[after] = struct{}{}
+			parents = append(parents, after)
+		}
+	}
+	return parents
 }
 
 func (p *Proxy) Stop(cleanupDNS bool) error {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -237,23 +237,30 @@ func (p *Proxy) WildcardParentCount() int {
 }
 
 func (p *Proxy) EnableServiceProxy(name string) bool {
-	if rt := p.router.byName[name]; rt != nil {
+	for _, rt := range p.router.routesFor(name) {
 		p.handler.invalidateCache(rt.domain)
 	}
 	return p.router.setEnabled(name, true)
 }
 
 func (p *Proxy) DisableServiceProxy(name string) bool {
-	if rt := p.router.byName[name]; rt != nil {
+	for _, rt := range p.router.routesFor(name) {
 		p.handler.invalidateCache(rt.domain)
 	}
 	return p.router.setEnabled(name, false)
 }
 
+// IsServiceProxyEnabled returns true if ANY route owned by the service is enabled;
+// matches prior behavior where the single-route map tracked one route's flag.
 func (p *Proxy) IsServiceProxyEnabled(name string) bool {
-	rt := p.router.byName[name]
-	if rt == nil {
+	routes := p.router.routesFor(name)
+	if len(routes) == 0 {
 		return false
 	}
-	return rt.enabled.Load()
+	for _, rt := range routes {
+		if rt.enabled.Load() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -163,6 +164,7 @@ func collectWildcardParents(cfg *config.Config) []string {
 			parents = append(parents, after)
 		}
 	}
+	sort.Strings(parents)
 	return parents
 }
 
@@ -242,14 +244,22 @@ func (p *Proxy) WildcardParentCount() int {
 
 func (p *Proxy) EnableServiceProxy(name string) bool {
 	for _, rt := range p.router.routesFor(name) {
-		p.handler.invalidateCache(rt.domain)
+		if rt.parent != "" {
+			p.handler.invalidateCacheSuffix(rt.parent)
+		} else {
+			p.handler.invalidateCache(rt.domain)
+		}
 	}
 	return p.router.setEnabled(name, true)
 }
 
 func (p *Proxy) DisableServiceProxy(name string) bool {
 	for _, rt := range p.router.routesFor(name) {
-		p.handler.invalidateCache(rt.domain)
+		if rt.parent != "" {
+			p.handler.invalidateCacheSuffix(rt.parent)
+		} else {
+			p.handler.invalidateCache(rt.domain)
+		}
 	}
 	return p.router.setEnabled(name, false)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -153,7 +153,7 @@ func (p *Proxy) Stop(cleanupDNS bool) error {
 	}
 
 	if cleanupDNS {
-		if err := p.sysDNS.Remove(); err != nil {
+		if err := p.sysDNS.remove(); err != nil {
 			errs = append(errs, fmt.Errorf("removing DNS entries: %w", err))
 		}
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -36,6 +36,20 @@ func TestStartPortConflict(t *testing.T) {
 	}
 }
 
+func TestWildcardParentsDeterministic(t *testing.T) {
+	cfgA := &config.Config{Services: map[string]config.Service{
+		"w": {Port: 8000, Subdomains: config.Subdomains{"*.b.test", "*.a.test"}},
+	}}
+	cfgB := &config.Config{Services: map[string]config.Service{
+		"w": {Port: 8000, Subdomains: config.Subdomains{"*.a.test", "*.b.test"}},
+	}}
+	a := collectWildcardParents(cfgA)
+	b := collectWildcardParents(cfgB)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("order differs: a=%v b=%v", a, b)
+	}
+}
+
 func TestProxyDetectsWildcard(t *testing.T) {
 	t.Run("no wildcard", func(t *testing.T) {
 		cfg := &config.Config{

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -20,7 +20,7 @@ func TestStartPortConflict(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "test.dev"},
 		Services: map[string]config.Service{
-			"svc": {Port: 9999, Subdomain: "app"},
+			"svc": {Port: 9999, Subdomains: config.Subdomains{"app"}},
 		},
 	}
 	p := New(cfg)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -33,4 +34,42 @@ func TestStartPortConflict(t *testing.T) {
 	if !strings.Contains(err.Error(), "binding port") {
 		t.Fatalf("expected 'binding port' error, got: %v", err)
 	}
+}
+
+func TestProxyDetectsWildcard(t *testing.T) {
+	t.Run("no wildcard", func(t *testing.T) {
+		cfg := &config.Config{
+			Proxy:    config.ProxyConfig{Domain: "test"},
+			Services: map[string]config.Service{"a": {Port: 1234, Subdomains: config.Subdomains{"a.test"}}},
+		}
+		p := New(cfg)
+		if p.hasWildcard {
+			t.Fatal("hasWildcard should be false for exact-only config")
+		}
+		if len(p.wildcardParents) != 0 {
+			t.Fatalf("want 0 parents, got %v", p.wildcardParents)
+		}
+	})
+
+	t.Run("with wildcard", func(t *testing.T) {
+		cfg := &config.Config{
+			Proxy: config.ProxyConfig{Domain: "test"},
+			Services: map[string]config.Service{
+				"a": {Port: 1234, Subdomains: config.Subdomains{"*.sellify.shop"}},
+				"b": {Port: 5678, Subdomains: config.Subdomains{"*.sellify.shop", "*.sellify.dev"}},
+			},
+		}
+		p := New(cfg)
+		if !p.hasWildcard {
+			t.Fatal("hasWildcard should be true")
+		}
+		want := map[string]bool{"sellify.shop": true, "sellify.dev": true}
+		got := map[string]bool{}
+		for _, parent := range p.wildcardParents {
+			got[parent] = true
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("parents=%v want=%v", p.wildcardParents, want)
+		}
+	})
 }

--- a/internal/proxy/resolver_darwin.go
+++ b/internal/proxy/resolver_darwin.go
@@ -3,6 +3,7 @@
 package proxy
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -29,6 +30,13 @@ func (r *resolverDir) Write(parents []string) error {
 	}
 	for _, p := range parents {
 		path := filepath.Join(r.base, p)
+		owned, err := r.loklOwnedOrAbsent(path)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			return fmt.Errorf("%s exists and is not managed by lokl; remove it manually and re-run dns setup", path)
+		}
 		content := fmt.Sprintf("%s\nnameserver 127.0.0.1\nport %d\n", macResolverMarker, r.port)
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", path, err)
@@ -40,11 +48,36 @@ func (r *resolverDir) Write(parents []string) error {
 func (r *resolverDir) Remove(parents []string) error {
 	for _, p := range parents {
 		path := filepath.Join(r.base, p)
+		owned, err := r.loklOwnedOrAbsent(path)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			continue
+		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing %s: %w", path, err)
 		}
 	}
 	return nil
+}
+
+// loklOwnedOrAbsent returns true when the file is absent or its first line is our marker.
+// Prevents clobbering foreign resolver files set up for VPNs, dnsmasq, etc.
+func (r *resolverDir) loklOwnedOrAbsent(path string) (bool, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	if scanner.Scan() {
+		return scanner.Text() == macResolverMarker, nil
+	}
+	return true, nil
 }
 
 func (r *resolverDir) Missing(parents []string) []string {

--- a/internal/proxy/resolver_darwin.go
+++ b/internal/proxy/resolver_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	macResolverDir    = "/etc/resolver"
+	macResolverMarker = "# managed by lokl"
+)
+
+type resolverDir struct {
+	base string
+	port int
+}
+
+func newResolverDir(port int) *resolverDir {
+	return &resolverDir{base: macResolverDir, port: port}
+}
+
+func (r *resolverDir) Write(parents []string) error {
+	if err := os.MkdirAll(r.base, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", r.base, err)
+	}
+	for _, p := range parents {
+		path := filepath.Join(r.base, p)
+		content := fmt.Sprintf("%s\nnameserver 127.0.0.1\nport %d\n", macResolverMarker, r.port)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (r *resolverDir) Remove(parents []string) error {
+	for _, p := range parents {
+		path := filepath.Join(r.base, p)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// FlushCache is best-effort; a stale cache is a minor UX issue, not a correctness one.
+func (r *resolverDir) FlushCache() error {
+	_ = exec.Command("dscacheutil", "-flushcache").Run()
+	_ = exec.Command("killall", "-HUP", "mDNSResponder").Run()
+	return nil
+}

--- a/internal/proxy/resolver_darwin.go
+++ b/internal/proxy/resolver_darwin.go
@@ -47,6 +47,16 @@ func (r *resolverDir) Remove(parents []string) error {
 	return nil
 }
 
+func (r *resolverDir) Missing(parents []string) []string {
+	var missing []string
+	for _, p := range parents {
+		if _, err := os.Stat(filepath.Join(r.base, p)); err != nil {
+			missing = append(missing, p)
+		}
+	}
+	return missing
+}
+
 // FlushCache is best-effort; a stale cache is a minor UX issue, not a correctness one.
 func (r *resolverDir) FlushCache() error {
 	_ = exec.Command("dscacheutil", "-flushcache").Run()

--- a/internal/proxy/resolver_darwin_test.go
+++ b/internal/proxy/resolver_darwin_test.go
@@ -52,3 +52,35 @@ func TestResolverFileLifecycle(t *testing.T) {
 		t.Fatalf("remove idempotent: %v", err)
 	}
 }
+
+func TestResolverFileRespectsForeignFiles(t *testing.T) {
+	dir := t.TempDir()
+	r := &resolverDir{base: dir, port: 5454}
+
+	foreign := filepath.Join(dir, "foreign.test")
+	if err := os.WriteFile(foreign, []byte("nameserver 9.9.9.9\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Write([]string{"foreign.test"}); err == nil {
+		t.Fatal("Write should refuse to overwrite a foreign resolver file")
+	}
+	if err := r.Remove([]string{"foreign.test"}); err != nil {
+		t.Fatalf("Remove should not error on foreign file: %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign file should survive Remove: %v", err)
+	}
+}
+
+func TestResolverFileOverwritesLoklOwned(t *testing.T) {
+	dir := t.TempDir()
+	r := &resolverDir{base: dir, port: 5454}
+
+	if err := r.Write([]string{"sellify.shop"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Write([]string{"sellify.shop"}); err != nil {
+		t.Fatalf("second Write on lokl-owned file should succeed: %v", err)
+	}
+}

--- a/internal/proxy/resolver_darwin_test.go
+++ b/internal/proxy/resolver_darwin_test.go
@@ -1,0 +1,54 @@
+//go:build darwin
+
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolverFileLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	r := &resolverDir{base: dir, port: 5454}
+
+	if err := r.Write([]string{"sellify.shop", "sellify.dev"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, parent := range []string{"sellify.shop", "sellify.dev"} {
+		b, err := os.ReadFile(filepath.Join(dir, parent))
+		if err != nil {
+			t.Fatalf("read %s: %v", parent, err)
+		}
+		content := string(b)
+		if !strings.Contains(content, "nameserver 127.0.0.1") {
+			t.Fatalf("missing nameserver line in %s:\n%s", parent, content)
+		}
+		if !strings.Contains(content, "port 5454") {
+			t.Fatalf("missing port line in %s:\n%s", parent, content)
+		}
+	}
+
+	// Idempotent second write.
+	if err := r.Write([]string{"sellify.shop", "sellify.dev"}); err != nil {
+		t.Fatalf("write again: %v", err)
+	}
+
+	// Removing one parent leaves the other intact.
+	if err := r.Remove([]string{"sellify.shop"}); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sellify.shop")); !os.IsNotExist(err) {
+		t.Fatalf("expected sellify.shop removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sellify.dev")); err != nil {
+		t.Fatalf("sellify.dev should still exist: %v", err)
+	}
+
+	// Remove is idempotent (no error when file is already gone).
+	if err := r.Remove([]string{"sellify.shop"}); err != nil {
+		t.Fatalf("remove idempotent: %v", err)
+	}
+}

--- a/internal/proxy/resolver_other.go
+++ b/internal/proxy/resolver_other.go
@@ -1,0 +1,19 @@
+//go:build !darwin
+
+package proxy
+
+import "errors"
+
+type resolverDir struct{ port int }
+
+func newResolverDir(port int) *resolverDir { return &resolverDir{port: port} }
+
+func (r *resolverDir) Write(parents []string) error {
+	if len(parents) == 0 {
+		return nil
+	}
+	return errors.New("wildcard DNS not supported on this platform yet (PR 2 adds Linux)")
+}
+
+func (r *resolverDir) Remove(parents []string) error { return nil }
+func (r *resolverDir) FlushCache() error             { return nil }

--- a/internal/proxy/resolver_other.go
+++ b/internal/proxy/resolver_other.go
@@ -12,7 +12,7 @@ func (r *resolverDir) Write(parents []string) error {
 	if len(parents) == 0 {
 		return nil
 	}
-	return errors.New("wildcard DNS not supported on this platform yet (PR 2 adds Linux)")
+	return errors.New("wildcard DNS is only supported on macOS today; Linux support is tracked for a future release")
 }
 
 func (r *resolverDir) Remove(parents []string) error { return nil }

--- a/internal/proxy/resolver_other.go
+++ b/internal/proxy/resolver_other.go
@@ -17,3 +17,7 @@ func (r *resolverDir) Write(parents []string) error {
 
 func (r *resolverDir) Remove(parents []string) error { return nil }
 func (r *resolverDir) FlushCache() error             { return nil }
+
+// Missing reports all parents as missing on unsupported platforms so callers
+// surface the gap instead of silently claiming DNS is wired up.
+func (r *resolverDir) Missing(parents []string) []string { return parents }

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -25,7 +25,7 @@ type rewriteConfig struct {
 type router struct {
 	baseDomain string
 	byHost     map[string][]*route
-	byName     map[string]*route
+	byName     map[string][]*route
 	wildcards  []*route
 }
 
@@ -33,7 +33,7 @@ func newRouter(cfg *config.Config) *router {
 	r := &router{
 		baseDomain: cfg.Proxy.Domain,
 		byHost:     make(map[string][]*route),
-		byName:     make(map[string]*route),
+		byName:     make(map[string][]*route),
 	}
 
 	for name, svc := range cfg.Services {
@@ -70,7 +70,7 @@ func newRouter(cfg *config.Config) *router {
 			} else {
 				r.byHost[fqdn] = append(r.byHost[fqdn], rt)
 			}
-			r.byName[name] = rt
+			r.byName[name] = append(r.byName[name], rt)
 		}
 	}
 
@@ -180,12 +180,18 @@ func (r *router) domain() string {
 }
 
 func (r *router) setEnabled(name string, enabled bool) bool {
-	rt, ok := r.byName[name]
-	if !ok {
+	routes, ok := r.byName[name]
+	if !ok || len(routes) == 0 {
 		return false
 	}
-	rt.enabled.Store(enabled)
+	for _, rt := range routes {
+		rt.enabled.Store(enabled)
+	}
 	return true
+}
+
+func (r *router) routesFor(name string) []*route {
+	return r.byName[name]
 }
 
 func prefixLen(rt *route) int {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -93,14 +93,49 @@ func (r *router) match(host, path string) *route {
 		host = host[:idx]
 	}
 
-	routes := r.byHost[host]
-	if len(routes) == 0 {
-		return nil
+	if routes := r.byHost[host]; len(routes) > 0 {
+		return selectByPath(routes, path)
 	}
+
+	for _, rt := range r.wildcards {
+		if !rt.enabled.Load() {
+			continue
+		}
+		if wildcardMatches(host, rt.parent) {
+			return selectByPath(wildcardsWithParent(r.wildcards, rt.parent), path)
+		}
+	}
+	return nil
+}
+
+// wildcardMatches enforces a dot boundary so evil-sellify.shop does not match *.sellify.shop.
+func wildcardMatches(host, parent string) bool {
+	prefix, ok := strings.CutSuffix(host, "."+parent)
+	if !ok || prefix == "" {
+		return false
+	}
+	for _, label := range strings.Split(prefix, ".") {
+		if label == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func wildcardsWithParent(all []*route, parent string) []*route {
+	out := make([]*route, 0, 1)
+	for _, rt := range all {
+		if rt.parent == parent {
+			out = append(out, rt)
+		}
+	}
+	return out
+}
+
+func selectByPath(routes []*route, path string) *route {
 	if len(routes) == 1 {
 		return routes[0]
 	}
-
 	for _, rt := range routes {
 		if rt.rewrite != nil && rt.rewrite.stripPrefix != "" {
 			prefix := "/" + rt.rewrite.stripPrefix
@@ -109,13 +144,11 @@ func (r *router) match(host, path string) *route {
 			}
 		}
 	}
-
 	for _, rt := range routes {
 		if rt.rewrite == nil || rt.rewrite.stripPrefix == "" {
 			return rt
 		}
 	}
-
 	return nil
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -157,6 +157,7 @@ func (r *router) domains() []string {
 	for domain := range r.byHost {
 		domains = append(domains, domain)
 	}
+	sort.Strings(domains)
 	return domains
 }
 
@@ -170,6 +171,7 @@ func (r *router) enabledDomains() []string {
 			}
 		}
 	}
+	sort.Strings(domains)
 	return domains
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -11,6 +11,7 @@ import (
 type route struct {
 	name    string
 	domain  string
+	parent  string
 	port    int
 	rewrite *rewriteConfig
 	enabled atomic.Bool
@@ -25,6 +26,7 @@ type router struct {
 	baseDomain string
 	byHost     map[string][]*route
 	byName     map[string]*route
+	wildcards  []*route
 }
 
 func newRouter(cfg *config.Config) *router {
@@ -62,7 +64,12 @@ func newRouter(cfg *config.Config) *router {
 				}
 			}
 
-			r.byHost[fqdn] = append(r.byHost[fqdn], rt)
+			if after, isWild := strings.CutPrefix(fqdn, "*."); isWild {
+				rt.parent = after
+				r.wildcards = append(r.wildcards, rt)
+			} else {
+				r.byHost[fqdn] = append(r.byHost[fqdn], rt)
+			}
 			r.byName[name] = rt
 		}
 	}
@@ -72,6 +79,10 @@ func newRouter(cfg *config.Config) *router {
 			return prefixLen(routes[i]) > prefixLen(routes[j])
 		})
 	}
+
+	sort.Slice(r.wildcards, func(i, j int) bool {
+		return len(r.wildcards[i].parent) > len(r.wildcards[j].parent)
+	})
 
 	return r
 }

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -80,7 +80,8 @@ func newRouter(cfg *config.Config) *router {
 		})
 	}
 
-	sort.Slice(r.wildcards, func(i, j int) bool {
+	// Longest parent first so nested wildcards (e.g. *.api.x.test) win over *.x.test during match.
+	sort.SliceStable(r.wildcards, func(i, j int) bool {
 		return len(r.wildcards[i].parent) > len(r.wildcards[j].parent)
 	})
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -35,31 +35,36 @@ func newRouter(cfg *config.Config) *router {
 	}
 
 	for name, svc := range cfg.Services {
-		if svc.Subdomain == "" || svc.Port == 0 {
+		if svc.Port == 0 {
 			continue
 		}
-
-		fqdn := svc.Subdomain
-		if !strings.Contains(svc.Subdomain, ".") && cfg.Proxy.Domain != "" {
-			fqdn = svc.Subdomain + "." + cfg.Proxy.Domain
-		}
-
-		rt := &route{
-			name:   name,
-			domain: fqdn,
-			port:   svc.Port,
-		}
-		rt.enabled.Store(true)
-
-		if svc.Rewrite != nil {
-			rt.rewrite = &rewriteConfig{
-				stripPrefix: strings.Trim(svc.Rewrite.StripPrefix, "/"),
-				fallback:    svc.Rewrite.Fallback,
+		for _, sd := range svc.Subdomains {
+			if sd == "" {
+				continue
 			}
-		}
 
-		r.byHost[fqdn] = append(r.byHost[fqdn], rt)
-		r.byName[name] = rt
+			fqdn := sd
+			if !strings.Contains(sd, ".") && cfg.Proxy.Domain != "" {
+				fqdn = sd + "." + cfg.Proxy.Domain
+			}
+
+			rt := &route{
+				name:   name,
+				domain: fqdn,
+				port:   svc.Port,
+			}
+			rt.enabled.Store(true)
+
+			if svc.Rewrite != nil {
+				rt.rewrite = &rewriteConfig{
+					stripPrefix: strings.Trim(svc.Rewrite.StripPrefix, "/"),
+					fallback:    svc.Rewrite.Fallback,
+				}
+			}
+
+			r.byHost[fqdn] = append(r.byHost[fqdn], rt)
+			r.byName[name] = rt
+		}
 	}
 
 	for _, routes := range r.byHost {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -98,9 +98,6 @@ func (r *router) match(host, path string) *route {
 	}
 
 	for _, rt := range r.wildcards {
-		if !rt.enabled.Load() {
-			continue
-		}
 		if wildcardMatches(host, rt.parent) {
 			return selectByPath(wildcardsWithParent(r.wildcards, rt.parent), path)
 		}

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -377,3 +377,51 @@ func TestRouterWildcardSortByParentLength(t *testing.T) {
 		t.Fatalf("wildcards[0].parent=%q, want longer parent first", r.wildcards[0].parent)
 	}
 }
+
+func TestRouterMatchWildcard(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.Service{
+			"web":      {Port: 8000, Subdomains: config.Subdomains{"sellify.shop", "*.sellify.shop"}},
+			"api":      {Port: 9000, Subdomains: config.Subdomains{"api.sellify.shop"}},
+			"api-deep": {Port: 9100, Subdomains: config.Subdomains{"*.api.sellify.shop"}},
+		},
+	}
+	r := newRouter(cfg)
+
+	cases := []struct {
+		host, want string
+	}{
+		{"sellify.shop", "web"},
+		{"api.sellify.shop", "api"},
+		{"foo.sellify.shop", "web"},
+		{"a.b.sellify.shop", "web"},
+		{"deep.api.sellify.shop", "api-deep"},
+		{"evil-sellify.shop", ""},
+		{"sellify.shop.attacker.com", ""},
+		{"nope.other.test", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			got := ""
+			if rt := r.match(tc.host, "/"); rt != nil {
+				got = rt.name
+			}
+			if got != tc.want {
+				t.Fatalf("match(%q)=%q want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouterMatchWildcardDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.Service{
+			"web": {Port: 8000, Subdomains: config.Subdomains{"*.sellify.shop"}},
+		},
+	}
+	r := newRouter(cfg)
+	r.wildcards[0].enabled.Store(false)
+	if rt := r.match("foo.sellify.shop", "/"); rt != nil {
+		t.Fatalf("disabled wildcard matched: %q", rt.name)
+	}
+}

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -435,7 +435,7 @@ func TestRouterSetEnabledTogglesAllRoutesForService(t *testing.T) {
 	}
 }
 
-func TestRouterMatchWildcardDisabled(t *testing.T) {
+func TestRouterMatchDisabledWildcardStillReturnsRoute(t *testing.T) {
 	cfg := &config.Config{
 		Services: map[string]config.Service{
 			"web": {Port: 8000, Subdomains: config.Subdomains{"*.sellify.shop"}},
@@ -443,7 +443,11 @@ func TestRouterMatchWildcardDisabled(t *testing.T) {
 	}
 	r := newRouter(cfg)
 	r.wildcards[0].enabled.Store(false)
-	if rt := r.match("foo.sellify.shop", "/"); rt != nil {
-		t.Fatalf("disabled wildcard matched: %q", rt.name)
+	rt := r.match("foo.sellify.shop", "/")
+	if rt == nil {
+		t.Fatal("disabled wildcard should still match; selectTarget decides local vs remote")
+	}
+	if rt.enabled.Load() {
+		t.Fatal("matched route should be disabled")
 	}
 }

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -329,3 +329,51 @@ func TestRouterEnabledDomainsSharedSubdomain(t *testing.T) {
 		t.Error("domain should be disabled (both routes disabled)")
 	}
 }
+
+func TestRouterBuildsWildcards(t *testing.T) {
+	cfg := &config.Config{
+		Proxy: config.ProxyConfig{Domain: ""},
+		Services: map[string]config.Service{
+			"web": {
+				Port:       8000,
+				Subdomains: config.Subdomains{"sellify.shop", "*.sellify.shop"},
+			},
+		},
+	}
+	r := newRouter(cfg)
+
+	if _, ok := r.byHost["sellify.shop"]; !ok {
+		t.Fatal("apex route missing from byHost")
+	}
+	if len(r.wildcards) != 1 {
+		t.Fatalf("want 1 wildcard, got %d", len(r.wildcards))
+	}
+	if r.wildcards[0].parent != "sellify.shop" {
+		t.Fatalf("parent=%q", r.wildcards[0].parent)
+	}
+	if r.wildcards[0].name != "web" {
+		t.Fatalf("name=%q", r.wildcards[0].name)
+	}
+	if r.wildcards[0].port != 8000 {
+		t.Fatalf("port=%d", r.wildcards[0].port)
+	}
+	if !r.wildcards[0].enabled.Load() {
+		t.Fatal("wildcard route should default to enabled")
+	}
+}
+
+func TestRouterWildcardSortByParentLength(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.Service{
+			"a": {Port: 8000, Subdomains: config.Subdomains{"*.sellify.shop"}},
+			"b": {Port: 8001, Subdomains: config.Subdomains{"*.api.sellify.shop"}},
+		},
+	}
+	r := newRouter(cfg)
+	if len(r.wildcards) != 2 {
+		t.Fatalf("want 2 wildcards, got %d", len(r.wildcards))
+	}
+	if r.wildcards[0].parent != "api.sellify.shop" {
+		t.Fatalf("wildcards[0].parent=%q, want longer parent first", r.wildcards[0].parent)
+	}
+}

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -413,6 +413,28 @@ func TestRouterMatchWildcard(t *testing.T) {
 	}
 }
 
+func TestRouterSetEnabledTogglesAllRoutesForService(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.Service{
+			"web": {Port: 8000, Subdomains: config.Subdomains{"sellify.shop", "*.sellify.shop"}},
+		},
+	}
+	r := newRouter(cfg)
+	if ok := r.setEnabled("web", false); !ok {
+		t.Fatal("setEnabled should return true for known service")
+	}
+	for _, rt := range r.byHost["sellify.shop"] {
+		if rt.enabled.Load() {
+			t.Fatal("exact apex route should be disabled")
+		}
+	}
+	for _, rt := range r.wildcards {
+		if rt.enabled.Load() {
+			t.Fatal("wildcard route should be disabled")
+		}
+	}
+}
+
 func TestRouterMatchWildcardDisabled(t *testing.T) {
 	cfg := &config.Config{
 		Services: map[string]config.Service{

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -10,10 +10,10 @@ func TestNewRouter(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
-			"web":          {Subdomain: "app", Port: 8080},
-			"api":          {Subdomain: "api", Port: 3000},
-			"no-subdomain": {Port: 5000},           // should be skipped
-			"no-port":      {Subdomain: "ignored"}, // should be skipped
+			"web":          {Subdomains: config.Subdomains{"app"}, Port: 8080},
+			"api":          {Subdomains: config.Subdomains{"api"}, Port: 3000},
+			"no-subdomain": {Port: 5000},                               // should be skipped
+			"no-port":      {Subdomains: config.Subdomains{"ignored"}}, // should be skipped
 		},
 	}
 
@@ -34,14 +34,14 @@ func TestRouterMatch(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"web": {
-				Subdomain: "app",
-				Port:      8080,
+				Subdomains: config.Subdomains{"app"},
+				Port:       8080,
 				Rewrite: &config.RewriteConfig{
 					StripPrefix: "web",
 					Fallback:    "/index.html",
 				},
 			},
-			"api": {Subdomain: "api.example.com", Port: 3000}, // FQDN already
+			"api": {Subdomains: config.Subdomains{"api.example.com"}, Port: 3000}, // FQDN already
 		},
 	}
 
@@ -84,8 +84,8 @@ func TestRouterMatchWithRewrite(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"web": {
-				Subdomain: "app",
-				Port:      8080,
+				Subdomains: config.Subdomains{"app"},
+				Port:       8080,
 				Rewrite: &config.RewriteConfig{
 					StripPrefix: "web",
 					Fallback:    "/index.html",
@@ -112,7 +112,7 @@ func TestRouterSetEnabled(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
-			"web": {Subdomain: "app", Port: 8080},
+			"web": {Subdomains: config.Subdomains{"app"}, Port: 8080},
 		},
 	}
 
@@ -143,8 +143,8 @@ func TestRouterEnabledDomains(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
-			"web": {Subdomain: "app", Port: 8080},
-			"api": {Subdomain: "api", Port: 3000},
+			"web": {Subdomains: config.Subdomains{"app"}, Port: 8080},
+			"api": {Subdomains: config.Subdomains{"api"}, Port: 3000},
 		},
 	}
 
@@ -166,14 +166,14 @@ func TestRouterMatchSharedSubdomain(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"funnel": {
-				Subdomain: "client",
-				Port:      8080,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "customer-funnel"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8080,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "customer-funnel"},
 			},
 			"activation": {
-				Subdomain: "client",
-				Port:      8083,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "activation/waipu"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8083,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "activation/waipu"},
 			},
 		},
 	}
@@ -209,14 +209,14 @@ func TestRouterMatchSegmentSafe(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"api": {
-				Subdomain: "app",
-				Port:      3000,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "api"},
+				Subdomains: config.Subdomains{"app"},
+				Port:       3000,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "api"},
 			},
 			"api2": {
-				Subdomain: "app",
-				Port:      3001,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "api2"},
+				Subdomains: config.Subdomains{"app"},
+				Port:       3001,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "api2"},
 			},
 		},
 	}
@@ -239,14 +239,14 @@ func TestRouterMatchNoPrefix404(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"a": {
-				Subdomain: "client",
-				Port:      8080,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "app-a"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8080,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "app-a"},
 			},
 			"b": {
-				Subdomain: "client",
-				Port:      8081,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "app-b"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8081,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "app-b"},
 			},
 		},
 	}
@@ -263,14 +263,14 @@ func TestRouterSetEnabledByName(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"funnel": {
-				Subdomain: "client",
-				Port:      8080,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "customer-funnel"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8080,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "customer-funnel"},
 			},
 			"activation": {
-				Subdomain: "client",
-				Port:      8083,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "activation/waipu"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8083,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "activation/waipu"},
 			},
 		},
 	}
@@ -301,14 +301,14 @@ func TestRouterEnabledDomainsSharedSubdomain(t *testing.T) {
 		Proxy: config.ProxyConfig{Domain: "example.com"},
 		Services: map[string]config.Service{
 			"a": {
-				Subdomain: "client",
-				Port:      8080,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "app-a"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8080,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "app-a"},
 			},
 			"b": {
-				Subdomain: "client",
-				Port:      8081,
-				Rewrite:   &config.RewriteConfig{StripPrefix: "app-b"},
+				Subdomains: config.Subdomains{"client"},
+				Port:       8081,
+				Rewrite:    &config.RewriteConfig{StripPrefix: "app-b"},
 			},
 		},
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -200,7 +200,7 @@ func (s *Supervisor) Services() []types.ServiceInfo {
 			Port: svc.Port,
 		}
 
-		if domain := s.serviceDomain(svc); domain != "" {
+		if domain := s.primaryDomain(svc); domain != "" {
 			item.Domain = domain
 			item.ProxyEnabled = s.proxyManager.IsServiceProxyEnabled(name)
 			if svc.Rewrite != nil {
@@ -247,7 +247,7 @@ func (s *Supervisor) cleanupStarted(names []string) {
 	}
 }
 
-func (s *Supervisor) serviceDomain(svc config.Service) string {
+func (s *Supervisor) primaryDomain(svc config.Service) string {
 	if len(svc.Subdomains) == 0 {
 		return ""
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -248,16 +248,20 @@ func (s *Supervisor) cleanupStarted(names []string) {
 }
 
 func (s *Supervisor) serviceDomain(svc config.Service) string {
-	if svc.Subdomain == "" {
+	if len(svc.Subdomains) == 0 {
 		return ""
 	}
-	if strings.Contains(svc.Subdomain, ".") {
-		return svc.Subdomain
+	sd := svc.Subdomains[0]
+	if sd == "" {
+		return ""
+	}
+	if strings.Contains(sd, ".") {
+		return sd
 	}
 	if s.cfg.Proxy.Domain == "" {
 		return ""
 	}
-	return svc.Subdomain + "." + s.cfg.Proxy.Domain
+	return sd + "." + s.cfg.Proxy.Domain
 }
 
 func (s *Supervisor) setupProxy() error {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -465,7 +465,7 @@ func TestToggleProxy(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"web": {Command: shCmd("npm start"), Subdomain: "app"},
+		"web": {Command: shCmd("npm start"), Subdomains: config.Subdomains{"app"}},
 	})
 	s := newTestSupervisor(cfg, nil, proxy)
 
@@ -528,8 +528,8 @@ func TestServices(t *testing.T) {
 	}
 
 	cfg := proxyConfig(map[string]config.Service{
-		"web": {Command: shCmd("npm start"), Port: 3000, Subdomain: "app"},
-		"api": {Command: shCmd("go run ."), Port: 8080, Subdomain: "api"},
+		"web": {Command: shCmd("npm start"), Port: 3000, Subdomains: config.Subdomains{"app"}},
+		"api": {Command: shCmd("go run ."), Port: 8080, Subdomains: config.Subdomains{"api"}},
 	})
 	s := newTestSupervisor(cfg, factory, proxy)
 
@@ -565,10 +565,10 @@ func TestServicesWithPathPrefix(t *testing.T) {
 
 	cfg := proxyConfig(map[string]config.Service{
 		"web": {
-			Command:   shCmd("npm start"),
-			Port:      3000,
-			Subdomain: "app",
-			Rewrite:   &config.RewriteConfig{StripPrefix: "web"},
+			Command:    shCmd("npm start"),
+			Port:       3000,
+			Subdomains: config.Subdomains{"app"},
+			Rewrite:    &config.RewriteConfig{StripPrefix: "web"},
 		},
 	})
 	s := newTestSupervisor(cfg, nil, proxy)
@@ -627,8 +627,8 @@ func TestServiceDomain(t *testing.T) {
 		svc  config.Service
 		want string
 	}{
-		{"subdomain expansion", config.Service{Subdomain: "api"}, "api.example.com"},
-		{"fqdn passthrough", config.Service{Subdomain: "api.other.com"}, "api.other.com"},
+		{"subdomain expansion", config.Service{Subdomains: config.Subdomains{"api"}}, "api.example.com"},
+		{"fqdn passthrough", config.Service{Subdomains: config.Subdomains{"api.other.com"}}, "api.other.com"},
 		{"empty subdomain", config.Service{}, ""},
 	}
 
@@ -646,7 +646,7 @@ func TestServiceDomainNoProxyDomain(t *testing.T) {
 	cfg := simpleConfig(nil)
 	s := newTestSupervisor(cfg, nil, nil)
 
-	got := s.serviceDomain(config.Service{Subdomain: "api"})
+	got := s.serviceDomain(config.Service{Subdomains: config.Subdomains{"api"}})
 	if got != "" {
 		t.Errorf("serviceDomain() = %q, want empty (no proxy domain)", got)
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -634,9 +634,9 @@ func TestServiceDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := s.serviceDomain(tt.svc)
+			got := s.primaryDomain(tt.svc)
 			if got != tt.want {
-				t.Errorf("serviceDomain() = %q, want %q", got, tt.want)
+				t.Errorf("primaryDomain() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -646,9 +646,9 @@ func TestServiceDomainNoProxyDomain(t *testing.T) {
 	cfg := simpleConfig(nil)
 	s := newTestSupervisor(cfg, nil, nil)
 
-	got := s.serviceDomain(config.Service{Subdomains: config.Subdomains{"api"}})
+	got := s.primaryDomain(config.Service{Subdomains: config.Subdomains{"api"}})
 	if got != "" {
-		t.Errorf("serviceDomain() = %q, want empty (no proxy domain)", got)
+		t.Errorf("primaryDomain() = %q, want empty (no proxy domain)", got)
 	}
 }
 

--- a/website/src/content/docs/config/proxy.md
+++ b/website/src/content/docs/config/proxy.md
@@ -85,6 +85,32 @@ Remove DNS entries:
 sudo lokl dns remove
 ```
 
+## Wildcard subdomains
+
+Multi-tenant apps (Laravel tenancy, Rails tenancy, per-customer previews) assign subdomains at runtime. `subdomain` accepts a list so one service can answer every tenant:
+
+```yaml
+services:
+  web:
+    command: php artisan serve
+    subdomain:
+      - sellify.shop
+      - "*.sellify.shop"
+    port: 8000
+```
+
+### How it works
+
+- `sudo lokl dns setup` writes `/etc/hosts` plus `/etc/resolver/sellify.shop` so macOS forwards wildcard lookups to lokl.
+- `lokl up` starts an in-process DNS listener on `127.0.0.1:5454` that answers every subdomain with `127.0.0.1`.
+- The proxy cert's SAN list covers both the apex (`sellify.shop`) and the wildcard (`*.sellify.shop`) — TLS works for every tenant.
+
+### Limits
+
+- `*` must be the leftmost label: `"*.x.y"` is valid; `"a.*.y"` and `"*"` are not.
+- Reserved parents (`*.com`, `*.local`, `*.test`, `*.localhost`) are rejected.
+- macOS only for now. Linux support (systemd-resolved) lands in a follow-up release.
+
 ## Toggle Proxy
 
 In the TUI, press `p` to toggle between:

--- a/website/src/content/docs/config/proxy.md
+++ b/website/src/content/docs/config/proxy.md
@@ -108,7 +108,7 @@ services:
 ### Limits
 
 - `*` must be the leftmost label: `"*.x.y"` is valid; `"a.*.y"` and `"*"` are not.
-- Reserved parents (`*.com`, `*.local`, `*.test`, `*.localhost`) are rejected.
+- Reserved parents (`*.com`, `*.org`, `*.net`, `*.local`, `*.test`, `*.localhost`) are rejected.
 - macOS only for now. Linux support (systemd-resolved) lands in a follow-up release.
 
 ## Toggle Proxy

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -59,7 +59,7 @@ services:
 | `env` | map | Environment variables |
 | `env_file` | list | Paths to `.env` files to load |
 | `volumes` | list | Volume mounts. `host:container` for bind mounts, `name:container` for named volumes, bare `/container/path` for anonymous volumes (mask a dir from an outer bind mount). |
-| `subdomain` | string | Subdomain for proxy routing |
+| `subdomain` | string or list of strings | Subdomain for proxy routing. A list may mix exact names and wildcards like `"*.sellify.shop"` for multi-tenant apps (macOS only for now). |
 | `depends_on` | list | Services to start first |
 | `health` | object | Health check configuration (see below) |
 | `autostart` | bool | Start automatically (default: true) |


### PR DESCRIPTION
## Summary

Unblocks multi-tenant apps (Laravel tenancy, Rails tenancy, per-customer previews) where subdomains are assigned at runtime.

- `subdomain` now accepts a scalar or a list. Wildcard entries like `"*.sellify.shop"` are supported; same service can declare both apex and wildcard.
- Router matches wildcards with label-boundary safety (`evil-sellify.shop` does NOT match `*.sellify.shop`) and longest-parent precedence.
- On macOS, `sudo lokl dns setup` writes `/etc/resolver/<parent>` files alongside the existing `/etc/hosts` block; `lokl up` starts an in-process DNS listener on `127.0.0.1:5454` (non-root, gated on wildcard presence). Cert SANs cover every apex + wildcard parent.
- Zero change for users who don't declare a wildcard — no new listener, no new sudo prompt, no new files.

## Out of scope

- Linux (systemd-resolved) lands in a follow-up PR.
- `proxy.dns_port` as a config field (hardcoded to 5454 today).

## Test plan

- [x] `make check` green (27 commits, full suite + vet + lint).
- [x] Unit coverage: config scalar/list unmarshal, wildcard validation (reject/accept shapes, reserved parents, duplicates), router exact+wildcard precedence, label-boundary attack, DNS server A/AAAA/REFUSED + apex refusal, resolver file write/remove/idempotent, cert SAN cache invalidation, per-service multi-route enable/disable.
- [x] Manual smoke on a real Laravel tenancy app: `sudo lokl dns setup` → `lokl up` → curls against apex, multiple tenant subdomains, and a sibling exact host (`s3.sellify.shop`) all return the right backends with valid TLS. `X-Lokl-Proxy: local` confirmed end-to-end.

## Docs

- README wildcard example added.
- `website/src/content/docs/config/proxy.md` has a new "Wildcard subdomains" section with how-it-works and limits.
- `services.md` subdomain row updated to reflect scalar-or-list type.