### PR TITLE
feat(config): proxy_only service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ services:
 
 macOS only for now; Linux support (systemd-resolved) is coming in a follow-up release.
 
+### Proxy-only services (one container, multiple HTTPS endpoints)
+
+Some containers expose two HTTP servers on different ports — MinIO's S3 API on 9000 and its console on 9001, Postgres + a pgAdmin sidecar, Jaeger UI on its own port. Declare a second service entry with `proxy_only: true` to route another subdomain to the second port without starting a second container:
+
+```yaml
+services:
+  minio:
+    image: minio/minio:latest
+    ports: ["9000:9000", "9001:9001"]
+    port: 9000
+    subdomain: s3
+
+  minio-console:
+    proxy_only: true
+    subdomain: console         # → https://console.<domain> → 127.0.0.1:9001
+    port: 9001
+    depends_on: [minio]
+```
+
+A `proxy_only` service doesn't start a process or container — it only forwards. Same pattern works for host-native processes (e.g. a Go server you run manually with `go run`) that you want reachable via HTTPS.
+
 Containers in the same lokl project share a bridge network (`lokl-{name}`).
 They can reach each other by service name — no need to expose ports between containers:
 

--- a/cmd/lokl/up.go
+++ b/cmd/lokl/up.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shahin-bayat/lokl/internal/lockfile"
 	"github.com/shahin-bayat/lokl/internal/process"
 	"github.com/shahin-bayat/lokl/internal/proxy"
+	"github.com/shahin-bayat/lokl/internal/runner/proxyonly"
 	"github.com/shahin-bayat/lokl/internal/supervisor"
 	"github.com/shahin-bayat/lokl/internal/tui"
 	"github.com/shahin-bayat/lokl/internal/types"
@@ -81,9 +82,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 	runners := make(map[string]supervisor.ProcessRunner)
 	pf := func(name string, svc config.Service, onChange func(), onCrash func()) supervisor.ProcessRunner {
 		var r supervisor.ProcessRunner
-		if svc.Image != "" {
+		switch {
+		case svc.ProxyOnly:
+			r = proxyonly.New(name, svc, onChange, onCrash)
+		case svc.Image != "":
 			r = docker.NewContainer(name, svc, dockerClient, projectNetwork, onChange, onCrash)
-		} else {
+		default:
 			r = process.New(name, svc, onChange, onCrash)
 		}
 		runners[name] = r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Service struct {
 	AutoStart    *bool  `yaml:"autostart"`
 	Restart      string `yaml:"restart"`
 	ReadyTimeout string `yaml:"ready_timeout"`
+	ProxyOnly    bool   `yaml:"proxy_only"`
 
 	Volumes []string `yaml:"volumes"`
 	Ports   []string `yaml:"ports"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,3 +545,32 @@ func TestSubdomainsUnmarshal(t *testing.T) {
 		}
 	})
 }
+
+func TestProxyOnlyField(t *testing.T) {
+	yml := `
+name: demo
+proxy: { domain: test }
+services:
+  console:
+    proxy_only: true
+    subdomain: console
+    port: 9001
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yml), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	svc, ok := cfg.Services["console"]
+	if !ok {
+		t.Fatal("console service missing")
+	}
+	if !svc.ProxyOnly {
+		t.Fatal("ProxyOnly should be true")
+	}
+	if svc.Port != 9001 {
+		t.Fatalf("port=%d want 9001", svc.Port)
+	}
+	if !slices.Equal(svc.Subdomains, []string{"console"}) {
+		t.Fatalf("subdomains=%v", svc.Subdomains)
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -20,6 +20,11 @@ func applyDefaults(cfg *Config) {
 	}
 
 	for name, svc := range cfg.Services {
+		if svc.ProxyOnly {
+			cfg.Services[name] = svc
+			continue
+		}
+
 		if svc.AutoStart == nil {
 			t := true
 			svc.AutoStart = &t

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -21,6 +21,9 @@ func applyDefaults(cfg *Config) {
 
 	for name, svc := range cfg.Services {
 		if svc.ProxyOnly {
+			if svc.Health != nil {
+				applyHealthDefaults(svc.Health)
+			}
 			cfg.Services[name] = svc
 			continue
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -76,7 +76,7 @@ func checkDuplicatePorts(services map[string]Service) error {
 
 func validateService(name string, svc *Service, services map[string]Service) error {
 	if svc.ProxyOnly {
-		return validateProxyOnlyService(name, svc)
+		return validateProxyOnlyService(name, svc, services)
 	}
 
 	hasCommand := svc.Command.IsSet()
@@ -250,7 +250,7 @@ var reservedWildcardParents = map[string]struct{}{
 	"local": {}, "localhost": {}, "test": {},
 }
 
-func validateProxyOnlyService(name string, svc *Service) error {
+func validateProxyOnlyService(name string, svc *Service, services map[string]Service) error {
 	if svc.Command.IsSet() || svc.Image != "" {
 		return fmt.Errorf("service %q: proxy_only cannot be combined with command or image", name)
 	}
@@ -286,6 +286,27 @@ func validateProxyOnlyService(name string, svc *Service) error {
 	}
 	if svc.Health != nil && svc.Health.Command.IsSet() {
 		return fmt.Errorf("service %q: health.command is not supported for proxy_only", name)
+	}
+	if svc.Health != nil {
+		if svc.Health.Interval != "" {
+			if _, err := time.ParseDuration(svc.Health.Interval); err != nil {
+				return fmt.Errorf("service %q: invalid health.interval %q: %w", name, svc.Health.Interval, err)
+			}
+		}
+		if svc.Health.Timeout != "" {
+			if _, err := time.ParseDuration(svc.Health.Timeout); err != nil {
+				return fmt.Errorf("service %q: invalid health.timeout %q: %w", name, svc.Health.Timeout, err)
+			}
+		}
+		if svc.Health.Retries != nil && *svc.Health.Retries < 0 {
+			return fmt.Errorf("service %q: health.retries must be non-negative", name)
+		}
+	}
+
+	for _, dep := range svc.DependsOn {
+		if _, exists := services[dep]; !exists {
+			return fmt.Errorf("service %q: depends_on references unknown service %q", name, dep)
+		}
 	}
 
 	return validateSubdomainsOnService(name, svc.Subdomains)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -98,22 +98,8 @@ func validateService(name string, svc *Service, services map[string]Service) err
 		return fmt.Errorf("service %q: port is required when subdomain is set", name)
 	}
 
-	seen := map[string]struct{}{}
-	for _, sd := range svc.Subdomains {
-		if _, dup := seen[sd]; dup {
-			return fmt.Errorf("service %q: duplicate subdomain %q", name, sd)
-		}
-		seen[sd] = struct{}{}
-
-		if after, isWild := strings.CutPrefix(sd, "*."); isWild {
-			if err := validateWildcardParent(after); err != nil {
-				return fmt.Errorf("service %q: subdomain %q: %w", name, sd, err)
-			}
-			continue
-		}
-		if strings.Contains(sd, "*") {
-			return fmt.Errorf("service %q: invalid subdomain %q", name, sd)
-		}
+	if err := validateSubdomainsOnService(name, svc.Subdomains); err != nil {
+		return err
 	}
 
 	if svc.Health != nil && svc.Health.Path != "" && svc.Port == 0 {
@@ -268,11 +254,29 @@ func validateProxyOnlyService(name string, svc *Service) error {
 	if svc.Command.IsSet() || svc.Image != "" {
 		return fmt.Errorf("service %q: proxy_only cannot be combined with command or image", name)
 	}
-	if len(svc.Ports) > 0 || len(svc.Volumes) > 0 || len(svc.Env) > 0 || len(svc.EnvFile) > 0 {
-		return fmt.Errorf("service %q: proxy_only cannot declare ports, volumes, env, or env_file", name)
+	if len(svc.Ports) > 0 {
+		return fmt.Errorf("service %q: proxy_only cannot declare ports", name)
 	}
-	if svc.AutoStart != nil || svc.Restart != "" || svc.ReadyTimeout != "" || svc.Limits != nil {
-		return fmt.Errorf("service %q: autostart, restart, ready_timeout, and limits are not supported for proxy_only", name)
+	if len(svc.Volumes) > 0 {
+		return fmt.Errorf("service %q: proxy_only cannot declare volumes", name)
+	}
+	if len(svc.Env) > 0 {
+		return fmt.Errorf("service %q: proxy_only cannot declare env", name)
+	}
+	if len(svc.EnvFile) > 0 {
+		return fmt.Errorf("service %q: proxy_only cannot declare env_file", name)
+	}
+	if svc.AutoStart != nil {
+		return fmt.Errorf("service %q: autostart is not supported for proxy_only", name)
+	}
+	if svc.Restart != "" {
+		return fmt.Errorf("service %q: restart is not supported for proxy_only", name)
+	}
+	if svc.ReadyTimeout != "" {
+		return fmt.Errorf("service %q: ready_timeout is not supported for proxy_only", name)
+	}
+	if svc.Limits != nil {
+		return fmt.Errorf("service %q: limits is not supported for proxy_only", name)
 	}
 	if svc.Port == 0 {
 		return fmt.Errorf("service %q: proxy_only requires port", name)
@@ -284,8 +288,15 @@ func validateProxyOnlyService(name string, svc *Service) error {
 		return fmt.Errorf("service %q: health.command is not supported for proxy_only", name)
 	}
 
+	return validateSubdomainsOnService(name, svc.Subdomains)
+}
+
+// validateSubdomainsOnService runs per-service subdomain checks (shape,
+// reserved parents, duplicates) that apply equally to normal and proxy_only
+// services.
+func validateSubdomainsOnService(name string, subdomains []string) error {
 	seen := map[string]struct{}{}
-	for _, sd := range svc.Subdomains {
+	for _, sd := range subdomains {
 		if _, dup := seen[sd]; dup {
 			return fmt.Errorf("service %q: duplicate subdomain %q", name, sd)
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -55,6 +55,9 @@ func checkDuplicatePorts(services map[string]Service) error {
 	}
 
 	for name, svc := range services {
+		if svc.ProxyOnly {
+			continue // forwards to a port rather than claiming it
+		}
 		if err := register(name, svc.Port); err != nil {
 			return err
 		}
@@ -72,6 +75,10 @@ func checkDuplicatePorts(services map[string]Service) error {
 }
 
 func validateService(name string, svc *Service, services map[string]Service) error {
+	if svc.ProxyOnly {
+		return validateProxyOnlyService(name, svc)
+	}
+
 	hasCommand := svc.Command.IsSet()
 	hasImage := svc.Image != ""
 
@@ -255,6 +262,45 @@ func checkDuplicateSubdomains(cfg *Config) error {
 var reservedWildcardParents = map[string]struct{}{
 	"com": {}, "org": {}, "net": {},
 	"local": {}, "localhost": {}, "test": {},
+}
+
+func validateProxyOnlyService(name string, svc *Service) error {
+	if svc.Command.IsSet() || svc.Image != "" {
+		return fmt.Errorf("service %q: proxy_only cannot be combined with command or image", name)
+	}
+	if len(svc.Ports) > 0 || len(svc.Volumes) > 0 || len(svc.Env) > 0 || len(svc.EnvFile) > 0 {
+		return fmt.Errorf("service %q: proxy_only cannot declare ports, volumes, env, or env_file", name)
+	}
+	if svc.AutoStart != nil || svc.Restart != "" || svc.ReadyTimeout != "" || svc.Limits != nil {
+		return fmt.Errorf("service %q: autostart, restart, ready_timeout, and limits are not supported for proxy_only", name)
+	}
+	if svc.Port == 0 {
+		return fmt.Errorf("service %q: proxy_only requires port", name)
+	}
+	if len(svc.Subdomains) == 0 {
+		return fmt.Errorf("service %q: proxy_only requires subdomain", name)
+	}
+	if svc.Health != nil && svc.Health.Command.IsSet() {
+		return fmt.Errorf("service %q: health.command is not supported for proxy_only", name)
+	}
+
+	seen := map[string]struct{}{}
+	for _, sd := range svc.Subdomains {
+		if _, dup := seen[sd]; dup {
+			return fmt.Errorf("service %q: duplicate subdomain %q", name, sd)
+		}
+		seen[sd] = struct{}{}
+		if after, isWild := strings.CutPrefix(sd, "*."); isWild {
+			if err := validateWildcardParent(after); err != nil {
+				return fmt.Errorf("service %q: subdomain %q: %w", name, sd, err)
+			}
+			continue
+		}
+		if strings.Contains(sd, "*") {
+			return fmt.Errorf("service %q: invalid subdomain %q", name, sd)
+		}
+	}
+	return nil
 }
 
 func validateWildcardParent(parent string) error {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -303,3 +303,99 @@ func TestProxyOnlyDoesNotInheritDefaults(t *testing.T) {
 		t.Fatalf("validate after defaults: %v", err)
 	}
 }
+
+func TestValidateProxyOnlyRejectsUnknownDependsOn(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+				DependsOn:  []string{"ghost"},
+			},
+		},
+	}
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected rejection on unknown depends_on for proxy_only")
+	}
+}
+
+func TestValidateProxyOnlyAcceptsKnownDependsOn(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"real": {
+				Command:    StringOrSlice{Args: []string{"sh"}, Shell: true},
+				Port:       8000,
+				Subdomains: Subdomains{"real"},
+			},
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+				DependsOn:  []string{"real"},
+			},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected acceptance, got %v", err)
+	}
+}
+
+func TestValidateProxyOnlyRejectsBadHealthInterval(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+				Health:     &HealthConfig{Path: "/h", Interval: "1 sec"},
+			},
+		},
+	}
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected rejection on malformed health.interval")
+	}
+}
+
+func TestValidateProxyOnlyRejectsBadHealthTimeout(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+				Health:     &HealthConfig{Path: "/h", Timeout: "500"},
+			},
+		},
+	}
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected rejection on malformed health.timeout")
+	}
+}
+
+func TestValidateProxyOnlyAcceptsValidHealthTimings(t *testing.T) {
+	retries := 5
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+				Health:     &HealthConfig{Path: "/h", Interval: "5s", Timeout: "2s", Retries: &retries},
+			},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected acceptance, got %v", err)
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -161,3 +161,82 @@ func TestProxyOnlyDoesNotTripDuplicatePorts(t *testing.T) {
 		t.Fatalf("proxy-only should not collide with published port: %v", err)
 	}
 }
+
+func TestValidateProxyOnlyRejectsEveryForbiddenField(t *testing.T) {
+	base := func() Service {
+		return Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"console"}}
+	}
+	t.Run("reject ports", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.Ports = []string{"9001:9001"}
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on ports")
+		}
+	})
+	t.Run("reject env", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.Env = map[string]string{"FOO": "bar"}
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on env")
+		}
+	})
+	t.Run("reject env_file", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.EnvFile = []string{".env"}
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on env_file")
+		}
+	})
+	t.Run("reject autostart", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		trueVal := true
+		svc.AutoStart = &trueVal
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on autostart")
+		}
+	})
+	t.Run("reject restart", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.Restart = "always"
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on restart")
+		}
+	})
+	t.Run("reject ready_timeout", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.ReadyTimeout = "5s"
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on ready_timeout")
+		}
+	})
+	t.Run("reject limits", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.Limits = &LimitsConfig{}
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on limits")
+		}
+	})
+	t.Run("reject bare asterisk subdomain", func(t *testing.T) {
+		cfg := &Config{Name: "demo", Proxy: ProxyConfig{Domain: "test"}, Services: map[string]Service{"bad": {}}}
+		svc := base()
+		svc.Subdomains = Subdomains{"*"}
+		cfg.Services["bad"] = svc
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on bare asterisk subdomain")
+		}
+	})
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -240,3 +240,43 @@ func TestValidateProxyOnlyRejectsEveryForbiddenField(t *testing.T) {
 		}
 	})
 }
+
+func TestProxyOnlyDoesNotInheritDefaults(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Env:   map[string]string{"GLOBAL": "1"},
+		Services: map[string]Service{
+			"real": {Command: StringOrSlice{Args: []string{"sh"}, Shell: true}, Port: 8000, Subdomains: Subdomains{"api"}},
+			"shim": {ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"shim"}},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	shim := cfg.Services["shim"]
+	if shim.AutoStart != nil {
+		t.Errorf("proxy-only AutoStart should remain nil, got %v", *shim.AutoStart)
+	}
+	if shim.Restart != "" {
+		t.Errorf("proxy-only Restart should remain empty, got %q", shim.Restart)
+	}
+	if len(shim.Env) != 0 {
+		t.Errorf("proxy-only Env should not inherit cfg.Env, got %v", shim.Env)
+	}
+
+	real := cfg.Services["real"]
+	if real.AutoStart == nil || !*real.AutoStart {
+		t.Errorf("normal service should default AutoStart=true, got %v", real.AutoStart)
+	}
+	if real.Restart != "on-failure" {
+		t.Errorf("normal service should default Restart=on-failure, got %q", real.Restart)
+	}
+	if real.Env["GLOBAL"] != "1" {
+		t.Errorf("normal service should inherit cfg.Env, got %v", real.Env)
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("validate after defaults: %v", err)
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -241,6 +241,29 @@ func TestValidateProxyOnlyRejectsEveryForbiddenField(t *testing.T) {
 	})
 }
 
+func TestProxyOnlyAppliesHealthDefaults(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"shim": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"shim"},
+				Health:     &HealthConfig{Path: "/healthz"},
+			},
+		},
+	}
+	applyDefaults(cfg)
+	h := cfg.Services["shim"].Health
+	if h == nil {
+		t.Fatal("Health should remain non-nil")
+	}
+	if h.Interval == "" || h.Timeout == "" || h.Retries == nil {
+		t.Fatalf("health defaults missing: %+v", h)
+	}
+}
+
 func TestProxyOnlyDoesNotInheritDefaults(t *testing.T) {
 	cfg := &Config{
 		Name:  "demo",

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -57,3 +57,107 @@ func TestValidateWildcardSubdomains(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateProxyOnly(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Name:  "demo",
+			Proxy: ProxyConfig{Domain: "test"},
+			Services: map[string]Service{
+				"real": {Command: StringOrSlice{Args: []string{"sh"}, Shell: true}, Port: 8000, Subdomains: Subdomains{"api"}},
+			},
+		}
+	}
+
+	t.Run("accept minimal", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["console"] = Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"console"}}
+		if err := validate(cfg); err != nil {
+			t.Fatalf("want accept, got %v", err)
+		}
+	})
+
+	t.Run("reject command", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"x"}, Command: StringOrSlice{Args: []string{"sh"}, Shell: true}}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on command+proxy_only")
+		}
+	})
+
+	t.Run("reject image", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"x"}, Image: "foo"}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on image+proxy_only")
+		}
+	})
+
+	t.Run("reject missing port", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{ProxyOnly: true, Subdomains: Subdomains{"x"}}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on missing port")
+		}
+	})
+
+	t.Run("reject missing subdomain", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{ProxyOnly: true, Port: 9001}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on missing subdomain")
+		}
+	})
+
+	t.Run("reject health command", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{
+			ProxyOnly:  true,
+			Port:       9001,
+			Subdomains: Subdomains{"x"},
+			Health:     &HealthConfig{Command: StringOrSlice{Args: []string{"true"}, Shell: true}},
+		}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on health.command+proxy_only")
+		}
+	})
+
+	t.Run("reject volumes", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["bad"] = Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"x"}, Volumes: []string{"./a:/b"}}
+		if err := validate(cfg); err == nil {
+			t.Fatal("expected rejection on volumes+proxy_only")
+		}
+	})
+
+	t.Run("accept wildcard subdomain", func(t *testing.T) {
+		cfg := base()
+		cfg.Services["tenant"] = Service{ProxyOnly: true, Port: 9001, Subdomains: Subdomains{"*.x.test"}}
+		if err := validate(cfg); err != nil {
+			t.Fatalf("wildcard subdomain should be accepted: %v", err)
+		}
+	})
+}
+
+func TestProxyOnlyDoesNotTripDuplicatePorts(t *testing.T) {
+	cfg := &Config{
+		Name:  "demo",
+		Proxy: ProxyConfig{Domain: "test"},
+		Services: map[string]Service{
+			"minio": {
+				Image:      "minio/minio",
+				Port:       9000,
+				Ports:      []string{"9000:9000", "9001:9001"},
+				Subdomains: Subdomains{"s3"},
+			},
+			"console": {
+				ProxyOnly:  true,
+				Port:       9001,
+				Subdomains: Subdomains{"console"},
+			},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Fatalf("proxy-only should not collide with published port: %v", err)
+	}
+}

--- a/internal/runner/proxyonly/runner.go
+++ b/internal/runner/proxyonly/runner.go
@@ -27,7 +27,9 @@ type Runner struct {
 	name     string
 	svc      config.Service
 	onChange func()
-	onCrash  func()
+	// onCrash is kept for factory-signature parity with process/docker runners;
+	// proxy-only services have no process, so it's never invoked.
+	onCrash func()
 
 	mu      sync.Mutex
 	running bool

--- a/internal/runner/proxyonly/runner.go
+++ b/internal/runner/proxyonly/runner.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	probeInterval = 2 * time.Second
-	probeTimeout  = 1 * time.Second
-	probeRetries  = 3
+	defaultProbeInterval = 2 * time.Second
+	defaultProbeTimeout  = 1 * time.Second
+	defaultProbeRetries  = 3
 )
 
 type Runner struct {
@@ -98,7 +98,33 @@ func (r *Runner) Logs() []string {
 	}
 }
 
+func (r *Runner) probeTimings() (interval, timeout time.Duration, retries int) {
+	interval = defaultProbeInterval
+	timeout = defaultProbeTimeout
+	retries = defaultProbeRetries
+
+	if r.svc.Health == nil {
+		return
+	}
+	if r.svc.Health.Interval != "" {
+		if d, err := time.ParseDuration(r.svc.Health.Interval); err == nil {
+			interval = d
+		}
+	}
+	if r.svc.Health.Timeout != "" {
+		if d, err := time.ParseDuration(r.svc.Health.Timeout); err == nil {
+			timeout = d
+		}
+	}
+	if r.svc.Health.Retries != nil {
+		retries = *r.svc.Health.Retries
+	}
+	return
+}
+
 func (r *Runner) probeLoop(ctx context.Context) {
+	interval, timeout, retries := r.probeTimings()
+
 	onChange := func(healthy bool) {
 		was := r.healthy.Load()
 		r.healthy.Store(healthy)
@@ -108,12 +134,12 @@ func (r *Runner) probeLoop(ctx context.Context) {
 	}
 
 	if r.svc.Health != nil && r.svc.Health.Path != "" {
-		runner.RunHealthCheck(ctx, r.svc.Port, r.svc.Health.Path, probeInterval, probeTimeout, probeRetries, onChange)
+		runner.RunHealthCheck(ctx, r.svc.Port, r.svc.Health.Path, interval, timeout, retries, onChange)
 		return
 	}
 
 	probe := func() bool {
-		d := net.Dialer{Timeout: probeTimeout}
+		d := net.Dialer{Timeout: timeout}
 		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", r.svc.Port))
 		if err != nil {
 			return false
@@ -121,5 +147,5 @@ func (r *Runner) probeLoop(ctx context.Context) {
 		_ = conn.Close()
 		return true
 	}
-	runner.RunProbe(ctx, probe, probeInterval, probeRetries, onChange)
+	runner.RunProbe(ctx, probe, interval, retries, onChange)
 }

--- a/internal/runner/proxyonly/runner.go
+++ b/internal/runner/proxyonly/runner.go
@@ -99,6 +99,19 @@ func (r *Runner) Logs() []string {
 }
 
 func (r *Runner) probeLoop(ctx context.Context) {
+	onChange := func(healthy bool) {
+		was := r.healthy.Load()
+		r.healthy.Store(healthy)
+		if was != healthy {
+			r.onChange()
+		}
+	}
+
+	if r.svc.Health != nil && r.svc.Health.Path != "" {
+		runner.RunHealthCheck(ctx, r.svc.Port, r.svc.Health.Path, probeInterval, probeTimeout, probeRetries, onChange)
+		return
+	}
+
 	probe := func() bool {
 		d := net.Dialer{Timeout: probeTimeout}
 		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", r.svc.Port))
@@ -108,11 +121,5 @@ func (r *Runner) probeLoop(ctx context.Context) {
 		_ = conn.Close()
 		return true
 	}
-	runner.RunProbe(ctx, probe, probeInterval, probeRetries, func(healthy bool) {
-		was := r.healthy.Load()
-		r.healthy.Store(healthy)
-		if was != healthy {
-			r.onChange()
-		}
-	})
+	runner.RunProbe(ctx, probe, probeInterval, probeRetries, onChange)
 }

--- a/internal/runner/proxyonly/runner.go
+++ b/internal/runner/proxyonly/runner.go
@@ -1,0 +1,116 @@
+// Package proxyonly implements a supervisor.ProcessRunner for services that
+// declare `proxy_only: true`. These services do not start a process or
+// container; they only register a forwarding route and run a TCP health
+// probe against 127.0.0.1:<port> so the TUI can reflect whether the target
+// is reachable.
+package proxyonly
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/shahin-bayat/lokl/internal/config"
+	"github.com/shahin-bayat/lokl/internal/runner"
+)
+
+const (
+	probeInterval = 2 * time.Second
+	probeTimeout  = 1 * time.Second
+	probeRetries  = 3
+)
+
+type Runner struct {
+	name     string
+	svc      config.Service
+	onChange func()
+	onCrash  func()
+
+	mu      sync.Mutex
+	running bool
+	cancel  context.CancelFunc
+	healthy atomic.Bool
+}
+
+func New(name string, svc config.Service, onChange, onCrash func()) *Runner {
+	return &Runner{
+		name:     name,
+		svc:      svc,
+		onChange: onChange,
+		onCrash:  onCrash,
+	}
+}
+
+func (r *Runner) Start() error {
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r.running = true
+	r.cancel = cancel
+	r.mu.Unlock()
+
+	go r.probeLoop(ctx)
+	r.onChange()
+	return nil
+}
+
+func (r *Runner) Stop() error {
+	r.mu.Lock()
+	if !r.running {
+		r.mu.Unlock()
+		return nil
+	}
+	r.running = false
+	cancel := r.cancel
+	r.cancel = nil
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	r.healthy.Store(false)
+	r.onChange()
+	return nil
+}
+
+func (r *Runner) IsRunning() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.running
+}
+
+func (r *Runner) IsHealthy() bool {
+	return r.healthy.Load()
+}
+
+func (r *Runner) Logs() []string {
+	return []string{
+		fmt.Sprintf("proxy-only service · forwarding to 127.0.0.1:%d", r.svc.Port),
+		"no process output",
+	}
+}
+
+func (r *Runner) probeLoop(ctx context.Context) {
+	probe := func() bool {
+		d := net.Dialer{Timeout: probeTimeout}
+		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", r.svc.Port))
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}
+	runner.RunProbe(ctx, probe, probeInterval, probeRetries, func(healthy bool) {
+		was := r.healthy.Load()
+		r.healthy.Store(healthy)
+		if was != healthy {
+			r.onChange()
+		}
+	})
+}

--- a/internal/runner/proxyonly/runner.go
+++ b/internal/runner/proxyonly/runner.go
@@ -107,16 +107,24 @@ func (r *Runner) probeTimings() (interval, timeout time.Duration, retries int) {
 		return
 	}
 	if r.svc.Health.Interval != "" {
-		if d, err := time.ParseDuration(r.svc.Health.Interval); err == nil {
+		d, err := time.ParseDuration(r.svc.Health.Interval)
+		if err != nil {
+			panic(fmt.Sprintf("proxy-only runner %q: invalid health.interval %q: %v", r.name, r.svc.Health.Interval, err))
+		}
+		if d > 0 {
 			interval = d
 		}
 	}
 	if r.svc.Health.Timeout != "" {
-		if d, err := time.ParseDuration(r.svc.Health.Timeout); err == nil {
+		d, err := time.ParseDuration(r.svc.Health.Timeout)
+		if err != nil {
+			panic(fmt.Sprintf("proxy-only runner %q: invalid health.timeout %q: %v", r.name, r.svc.Health.Timeout, err))
+		}
+		if d > 0 {
 			timeout = d
 		}
 	}
-	if r.svc.Health.Retries != nil {
+	if r.svc.Health.Retries != nil && *r.svc.Health.Retries > 0 {
 		retries = *r.svc.Health.Retries
 	}
 	return

--- a/internal/runner/proxyonly/runner_test.go
+++ b/internal/runner/proxyonly/runner_test.go
@@ -177,6 +177,42 @@ func TestRunnerUnhealthyViaHTTPPath(t *testing.T) {
 	}
 }
 
+func TestRunnerHonorsHealthInterval(t *testing.T) {
+	five := 5
+	svc := config.Service{
+		ProxyOnly:  true,
+		Port:       9999,
+		Subdomains: config.Subdomains{"x"},
+		Health:     &config.HealthConfig{Interval: "100ms", Timeout: "50ms", Retries: &five},
+	}
+	r := New("x", svc, func() {}, func() {})
+	interval, timeout, retries := r.probeTimings()
+	if interval != 100*time.Millisecond {
+		t.Errorf("interval=%v, want 100ms", interval)
+	}
+	if timeout != 50*time.Millisecond {
+		t.Errorf("timeout=%v, want 50ms", timeout)
+	}
+	if retries != 5 {
+		t.Errorf("retries=%d, want 5", retries)
+	}
+}
+
+func TestRunnerFallsBackToDefaultsWhenHealthOmitted(t *testing.T) {
+	svc := config.Service{ProxyOnly: true, Port: 9999, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() {}, func() {})
+	interval, timeout, retries := r.probeTimings()
+	if interval != defaultProbeInterval {
+		t.Errorf("interval=%v, want %v", interval, defaultProbeInterval)
+	}
+	if timeout != defaultProbeTimeout {
+		t.Errorf("timeout=%v, want %v", timeout, defaultProbeTimeout)
+	}
+	if retries != defaultProbeRetries {
+		t.Errorf("retries=%d, want %d", retries, defaultProbeRetries)
+	}
+}
+
 func TestRunnerStopIsIdempotent(t *testing.T) {
 	svc := config.Service{ProxyOnly: true, Port: 9999, Subdomains: config.Subdomains{"x"}}
 	r := New("x", svc, func() {}, func() {})

--- a/internal/runner/proxyonly/runner_test.go
+++ b/internal/runner/proxyonly/runner_test.go
@@ -1,0 +1,108 @@
+package proxyonly
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shahin-bayat/lokl/internal/config"
+)
+
+func TestRunnerStartStop(t *testing.T) {
+	svc := config.Service{ProxyOnly: true, Port: 0, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() {}, func() {})
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !r.IsRunning() {
+		t.Fatal("IsRunning should be true after Start")
+	}
+	if err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if r.IsRunning() {
+		t.Fatal("IsRunning should be false after Stop")
+	}
+}
+
+func TestRunnerHealthyWhenTargetListens(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+
+	var changes atomic.Int32
+	svc := config.Service{ProxyOnly: true, Port: port, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() { changes.Add(1) }, func() {})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Stop() })
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.IsHealthy() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("IsHealthy did not become true within 5s (onChange calls=%d)", changes.Load())
+}
+
+func TestRunnerUnhealthyWhenNoListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	svc := config.Service{ProxyOnly: true, Port: port, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() {}, func() {})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Stop() })
+
+	time.Sleep(2500 * time.Millisecond)
+	if r.IsHealthy() {
+		t.Fatal("IsHealthy should remain false when nothing listens on target port")
+	}
+}
+
+func TestRunnerLogsBanner(t *testing.T) {
+	svc := config.Service{ProxyOnly: true, Port: 9999, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() {}, func() {})
+	logs := r.Logs()
+	if len(logs) == 0 {
+		t.Fatal("Logs should return a banner")
+	}
+}
+
+func TestRunnerStopIsIdempotent(t *testing.T) {
+	svc := config.Service{ProxyOnly: true, Port: 9999, Subdomains: config.Subdomains{"x"}}
+	r := New("x", svc, func() {}, func() {})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Stop(); err != nil {
+		t.Fatalf("second Stop should be no-op: %v", err)
+	}
+}

--- a/internal/runner/proxyonly/runner_test.go
+++ b/internal/runner/proxyonly/runner_test.go
@@ -2,6 +2,11 @@ package proxyonly
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -90,6 +95,85 @@ func TestRunnerLogsBanner(t *testing.T) {
 	logs := r.Logs()
 	if len(logs) == 0 {
 		t.Fatal("Logs should return a banner")
+	}
+}
+
+func TestRunnerHealthyViaHTTPPath(t *testing.T) {
+	ready := make(chan struct{})
+	var mu sync.Mutex
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(200)
+			select {
+			case ready <- struct{}{}:
+			default:
+			}
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	t.Cleanup(srv.Close)
+
+	port, err := strconv.Atoi(strings.TrimPrefix(srv.URL, "http://127.0.0.1:"))
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	svc := config.Service{
+		ProxyOnly:  true,
+		Port:       port,
+		Subdomains: config.Subdomains{"x"},
+		Health:     &config.HealthConfig{Path: "/healthz"},
+	}
+	r := New("x", svc, func() {}, func() {})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = r.Stop() })
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.IsHealthy() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	mu.Lock()
+	calls := callCount
+	mu.Unlock()
+	t.Fatalf("IsHealthy did not flip to true within 5s (probe calls=%d)", calls)
+}
+
+func TestRunnerUnhealthyViaHTTPPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+	}))
+	t.Cleanup(srv.Close)
+
+	port, err := strconv.Atoi(strings.TrimPrefix(srv.URL, "http://127.0.0.1:"))
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	svc := config.Service{
+		ProxyOnly:  true,
+		Port:       port,
+		Subdomains: config.Subdomains{"x"},
+		Health:     &config.HealthConfig{Path: "/healthz"},
+	}
+	r := New("x", svc, func() {}, func() {})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = r.Stop() })
+
+	time.Sleep(2500 * time.Millisecond)
+	if r.IsHealthy() {
+		t.Fatal("IsHealthy must stay false when HTTP probe gets 503")
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -196,8 +196,9 @@ func (s *Supervisor) Services() []types.ServiceInfo {
 	for _, name := range sorted {
 		svc := s.cfg.Services[name]
 		item := types.ServiceInfo{
-			Name: name,
-			Port: svc.Port,
+			Name:      name,
+			Port:      svc.Port,
+			ProxyOnly: svc.ProxyOnly,
 		}
 
 		if domain := s.primaryDomain(svc); domain != "" {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -163,6 +163,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "r":
 		if svc := m.selectedService(); svc != nil {
+			if svc.ProxyOnly {
+				m.copyMsg = "proxy-only services have no process to restart"
+				m.copyExpiry = time.Now().Add(copyFlashDuration)
+				return m, copyFlashTimeout()
+			}
 			_ = m.controller.RestartService(svc.Name)
 		}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -153,11 +153,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "s":
 		if svc := m.selectedService(); svc != nil {
+			if svc.ProxyOnly {
+				m.copyMsg = "proxy-only services have no process to start"
+				m.copyExpiry = time.Now().Add(copyFlashDuration)
+				return m, copyFlashTimeout()
+			}
 			_ = m.controller.StartService(svc.Name)
 		}
 
 	case "x":
 		if svc := m.selectedService(); svc != nil {
+			if svc.ProxyOnly {
+				m.copyMsg = "proxy-only services have no process to stop"
+				m.copyExpiry = time.Now().Add(copyFlashDuration)
+				return m, copyFlashTimeout()
+			}
 			_ = m.controller.StopService(svc.Name)
 		}
 

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/shahin-bayat/lokl/internal/types"
+)
+
+type restartFakeController struct {
+	svcs         []types.ServiceInfo
+	restartCalls int
+}
+
+func (f *restartFakeController) StartService(_ string) error { return nil }
+func (f *restartFakeController) StopService(_ string) error  { return nil }
+func (f *restartFakeController) RestartService(_ string) error {
+	f.restartCalls++
+	return nil
+}
+func (f *restartFakeController) ToggleProxy(_ string) (bool, error) { return false, nil }
+func (f *restartFakeController) Services() []types.ServiceInfo      { return f.svcs }
+func (f *restartFakeController) ServiceLogs(_ string) []string      { return nil }
+func (f *restartFakeController) ProjectName() string                { return "test" }
+func (f *restartFakeController) Subscribe() <-chan types.Event      { return make(chan types.Event) }
+
+func TestRestartKeyNoopsOnProxyOnly(t *testing.T) {
+	ctrl := &restartFakeController{
+		svcs: []types.ServiceInfo{
+			{Name: "console", Port: 9001, ProxyOnly: true, Running: true},
+		},
+	}
+	m := newModel(ctrl)
+	m.selectedIdx = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if ctrl.restartCalls != 0 {
+		t.Fatalf("RestartService should not be called on proxy-only; calls=%d", ctrl.restartCalls)
+	}
+	if !strings.Contains(m.copyMsg, "proxy-only") {
+		t.Fatalf("expected toast about proxy-only; got %q", m.copyMsg)
+	}
+}
+
+func TestRestartKeyCallsRestartOnNormalService(t *testing.T) {
+	ctrl := &restartFakeController{
+		svcs: []types.ServiceInfo{
+			{Name: "api", Port: 3000, Running: true},
+		},
+	}
+	m := newModel(ctrl)
+	m.selectedIdx = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	updated, _ := m.Update(msg)
+	_ = updated.(Model)
+
+	if ctrl.restartCalls != 1 {
+		t.Fatalf("RestartService should be called once; got %d", ctrl.restartCalls)
+	}
+}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -12,10 +12,18 @@ import (
 type restartFakeController struct {
 	svcs         []types.ServiceInfo
 	restartCalls int
+	startCalls   int
+	stopCalls    int
 }
 
-func (f *restartFakeController) StartService(_ string) error { return nil }
-func (f *restartFakeController) StopService(_ string) error  { return nil }
+func (f *restartFakeController) StartService(_ string) error {
+	f.startCalls++
+	return nil
+}
+func (f *restartFakeController) StopService(_ string) error {
+	f.stopCalls++
+	return nil
+}
 func (f *restartFakeController) RestartService(_ string) error {
 	f.restartCalls++
 	return nil
@@ -62,5 +70,47 @@ func TestRestartKeyCallsRestartOnNormalService(t *testing.T) {
 
 	if ctrl.restartCalls != 1 {
 		t.Fatalf("RestartService should be called once; got %d", ctrl.restartCalls)
+	}
+}
+
+func TestStartKeyNoopsOnProxyOnly(t *testing.T) {
+	ctrl := &restartFakeController{
+		svcs: []types.ServiceInfo{
+			{Name: "console", Port: 9001, ProxyOnly: true, Running: false},
+		},
+	}
+	m := newModel(ctrl)
+	m.selectedIdx = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if ctrl.startCalls != 0 {
+		t.Fatalf("StartService should not be called on proxy-only; calls=%d", ctrl.startCalls)
+	}
+	if !strings.Contains(m.copyMsg, "proxy-only") {
+		t.Fatalf("expected proxy-only toast; got %q", m.copyMsg)
+	}
+}
+
+func TestStopKeyNoopsOnProxyOnly(t *testing.T) {
+	ctrl := &restartFakeController{
+		svcs: []types.ServiceInfo{
+			{Name: "console", Port: 9001, ProxyOnly: true, Running: true},
+		},
+	}
+	m := newModel(ctrl)
+	m.selectedIdx = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if ctrl.stopCalls != 0 {
+		t.Fatalf("StopService should not be called on proxy-only; calls=%d", ctrl.stopCalls)
+	}
+	if !strings.Contains(m.copyMsg, "proxy-only") {
+		t.Fatalf("expected proxy-only toast; got %q", m.copyMsg)
 	}
 }

--- a/internal/types/service.go
+++ b/internal/types/service.go
@@ -9,4 +9,5 @@ type ServiceInfo struct {
 	Running      bool
 	Healthy      bool
 	ProxyEnabled bool
+	ProxyOnly    bool
 }

--- a/website/src/content/docs/config/proxy.md
+++ b/website/src/content/docs/config/proxy.md
@@ -111,6 +111,8 @@ services:
 - Reserved parents (`*.com`, `*.org`, `*.net`, `*.local`, `*.test`, `*.localhost`) are rejected.
 - macOS only for now. Linux support (systemd-resolved) lands in a follow-up release.
 
+A service with `proxy_only: true` registers a subdomain route without starting a process or container — useful when one container exposes multiple HTTP ports (MinIO API + console) or when a subdomain should forward to a host-native process. See the [services documentation](/lokl/config/services/#proxy-only-services) for the full example.
+
 ## Toggle Proxy
 
 In the TUI, press `p` to toggle between:

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -255,7 +255,7 @@ services:
 
 ### Disallowed fields
 
-`command`, `image`, `ports`, `volumes`, `env`, `env_file`, `autostart`, `restart`, `ready_timeout`, `limits`, `health.command`. Validation rejects these with a clear error naming the field.
+`command`, `image`, `ports`, `volumes`, `env`, `env_file`, `autostart`, `restart`, `ready_timeout`, `limits`, `health.command`. Validation rejects these with a clear error message.
 
 ### Notes
 

--- a/website/src/content/docs/config/services.md
+++ b/website/src/content/docs/config/services.md
@@ -29,6 +29,7 @@ services:
 | `depends_on` | list | Services to start first |
 | `autostart` | bool | Start automatically (default: true) |
 | `restart` | string | Restart policy: `no`, `always`, `on-failure` |
+| `proxy_only` | bool | Register the subdomain route without starting a process or container. Requires `port` and `subdomain`. See [Proxy-only services](#proxy-only-services). |
 
 ## Container-based Services
 
@@ -64,6 +65,7 @@ services:
 | `health` | object | Health check configuration (see below) |
 | `autostart` | bool | Start automatically (default: true) |
 | `restart` | string | Restart policy: `no`, `always`, `on-failure` |
+| `proxy_only` | bool | Register the subdomain route without starting a process or container. Requires `port` and `subdomain`. See [Proxy-only services](#proxy-only-services). |
 
 :::note
 - When `port` is set with `ports`, the port value must appear as a host port in one of the mappings.
@@ -217,3 +219,46 @@ services:
 ```
 
 Variables are resolved against the host's environment at config load time. Missing variables expand to an empty string.
+
+## Proxy-only services
+
+A service entry with `proxy_only: true` registers a subdomain route without starting a process or container. Useful for:
+
+- **One container, multiple HTTPS endpoints** — MinIO API + console, Postgres + pgAdmin, Jaeger UI on a second port.
+- **Host-native processes** — a Go server or Python script you run manually; lokl gives it a trusted HTTPS URL without managing its lifecycle.
+
+```yaml
+services:
+  minio:
+    image: minio/minio:latest
+    ports: ["9000:9000", "9001:9001"]
+    port: 9000
+    subdomain: s3
+
+  minio-console:
+    proxy_only: true
+    subdomain: console
+    port: 9001
+    depends_on: [minio]
+```
+
+### Required fields
+
+- `port` — the target port lokl forwards to (always `127.0.0.1:<port>` over HTTP).
+- `subdomain` — scalar or list; wildcards like `"*.x.test"` work the same as for regular services.
+
+### Allowed optional fields
+
+- `depends_on` — wait for another service to be healthy before probing.
+- `rewrite.strip_prefix` / `rewrite.fallback` — path aliasing, same as normal services.
+- `health.path` — HTTP readiness probe instead of the default TCP probe.
+
+### Disallowed fields
+
+`command`, `image`, `ports`, `volumes`, `env`, `env_file`, `autostart`, `restart`, `ready_timeout`, `limits`, `health.command`. Validation rejects these with a clear error naming the field.
+
+### Notes
+
+- The target port can belong to a lokl-managed container (via its `ports:` publish) or to a host-native process the user runs themselves — lokl just dials `127.0.0.1:<port>`.
+- The duplicate-port validator ignores proxy-only services — they forward, not bind.
+- In the TUI, proxy-only services appear in the service list with a TCP-probe-backed status dot. The restart key is a no-op (no process to restart). The log panel shows a static banner.


### PR DESCRIPTION
## Summary

Adds \`proxy_only: true\` to \`Service\` — registers a subdomain route without starting a process or container and without claiming the target port in the duplicate-port validator. Unblocks one-container-multiple-HTTPS-endpoints (MinIO API + console, Postgres + pgAdmin, Jaeger UI) and routing to host-native processes lokl doesn't manage.

- **Config:** new boolean \`ProxyOnly\` on \`Service\`. Validation rejects process/container fields (\`command\`, \`image\`, \`ports\`, \`volumes\`, \`env\`, \`env_file\`, \`autostart\`, \`restart\`, \`ready_timeout\`, \`limits\`, \`health.command\`) and requires \`port\` + \`subdomain\`. \`checkDuplicatePorts\` ignores proxy-only services on the owner side; \`applyDefaults\` skips lifecycle defaults for them so the validator stays strict.
- **Runner:** \`internal/runner/proxyonly\` implements \`supervisor.ProcessRunner\` with a trivial lifecycle. Default TCP probe on \`127.0.0.1:<port>\`; HTTP probe when \`health.path\` is set.
- **Factory:** \`cmd/lokl/up.go\` routes \`ProxyOnly\` services to the new runner.
- **TUI:** \`r\` key is a no-op with a toast for proxy-only rows; log panel shows a \`proxy-only service · forwarding to 127.0.0.1:<port>\` banner from \`Runner.Logs()\`.
- **Router, cert manager, DNS, handler:** zero changes — proxy-only services flow through the existing paths via \`Service.Subdomains\` + \`Service.Port\`.
- **Wildcard compatible** — works with the scalar-or-list \`subdomain\` semantics from #57.

## Test plan
- [x] \`make check\` green across 10 commits.
- [x] Unit: accept/reject matrix for each forbidden field (8 subtests); defaults-skipping for proxy-only; runner health transitions (TCP and HTTP path).
- [x] Manual smoke on a real Laravel tenancy app:
  - MinIO published on 9000 (API) + 9001 (console).
  - Primary service \`minio\` owns \`subdomain: s3\` → \`https://s3.sellify.shop\`.
  - New \`proxy_only\` service \`minio-console\` owns \`subdomain: console\` → \`https://console.sellify.shop\` → \`127.0.0.1:9001\`.
  - \`MINIO_BROWSER_REDIRECT_URL\` set on minio so the API host redirects browsers to the console URL cleanly.
  - Laravel app + tenant wildcards continue to route via \`https://sellify.shop\` and \`https://<tenant>.sellify.shop\`.
  - All three subdomains served with trusted TLS (mkcert); \`X-Lokl-Proxy: local\` confirmed.