### PR TITLE
fix(proxy): add ::1 entries to /etc/hosts for IPv6-preferring browsers

### DIFF
--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -98,6 +98,7 @@ func (d *dnsManager) add(domains []string) error {
 	block.WriteString(d.startMarker() + "\n")
 	for _, domain := range domains {
 		fmt.Fprintf(&block, "127.0.0.1 %s\n", domain)
+		fmt.Fprintf(&block, "::1 %s\n", domain)
 	}
 	block.WriteString(d.endMarker() + "\n")
 
@@ -241,6 +242,7 @@ func (d *dnsManager) block(domains []string) string {
 	b.WriteString(d.startMarker() + "\n")
 	for _, domain := range domains {
 		fmt.Fprintf(&b, "127.0.0.1 %s\n", domain)
+		fmt.Fprintf(&b, "::1 %s\n", domain)
 	}
 	b.WriteString(d.endMarker())
 	return b.String()

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -258,7 +259,9 @@ func TestHostsManagerBlock(t *testing.T) {
 
 	want := `# lokl:myproject - START
 127.0.0.1 app.example.com
+::1 app.example.com
 127.0.0.1 api.example.com
+::1 api.example.com
 # lokl:myproject - END`
 
 	if got != want {
@@ -274,6 +277,40 @@ func TestHostsManagerBlockEmpty(t *testing.T) {
 
 	if got != want {
 		t.Errorf("block(nil):\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestAddEmitsBothAddressFamilies(t *testing.T) {
+	tmp := t.TempDir()
+	hostsPath := filepath.Join(tmp, "hosts")
+	if err := os.WriteFile(hostsPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &dnsManager{project: "demo", hostsPath: hostsPath}
+	if err := d.add([]string{"a.test", "b.test"}); err != nil {
+		t.Fatal(err)
+	}
+	content, _ := os.ReadFile(hostsPath)
+	s := string(content)
+
+	for _, host := range []string{"a.test", "b.test"} {
+		if !strings.Contains(s, "127.0.0.1 "+host) {
+			t.Errorf("missing IPv4 entry for %s in:\n%s", host, s)
+		}
+		if !strings.Contains(s, "::1 "+host) {
+			t.Errorf("missing IPv6 entry for %s in:\n%s", host, s)
+		}
+	}
+}
+
+func TestBlockIncludesBothAddressFamilies(t *testing.T) {
+	d := &dnsManager{project: "demo"}
+	out := d.block([]string{"a.test"})
+	if !strings.Contains(out, "127.0.0.1 a.test") {
+		t.Errorf("block missing IPv4 line:\n%s", out)
+	}
+	if !strings.Contains(out, "::1 a.test") {
+		t.Errorf("block missing IPv6 line:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Chrome 147+ (released 2026-04-28) uses Happy Eyeballs v2 (RFC 8305) and prefers IPv6 when the hostname has any AAAA record. lokl's `/etc/hosts` block emits only IPv4 entries (`127.0.0.1 <host>`). For service hostnames whose public DNS has AAAA records (e.g. `client.waipu-dev.net`), Chrome resolved the public IPv6 from upstream DNS instead of the local 127.0.0.1, bypassing lokl entirely.

Symptom: visiting a configured local domain in Chrome served the **deployed** environment instead of the local proxy. Safari / curl / nslookup were unaffected because they default to IPv4 lookup or honor `/etc/hosts` differently.

## Fix

Emit both `127.0.0.1 <host>` and `::1 <host>` lines per domain in the lokl-managed `/etc/hosts` block.

- `internal/proxy/dns.go` `(*dnsManager).add()` and `block()` updated.
- `removeBlock()` unchanged — strips by start/end markers regardless of content.
- Wildcard hosts already worked: the embedded DNS server (PR #57) answers AAAA → ::1 directly.

## How to verify locally

1. Pull this branch and rebuild: `make build`.
2. Refresh the hosts block: `sudo ./lokl dns setup`.
3. Confirm both address families are present:
   ```
   grep '<your-domain>' /etc/hosts
   ```
   Expect two lines per host: `127.0.0.1 <host>` and `::1 <host>`.
4. Flush caches:
   ```
   sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
   ```
5. Open `chrome://net-internals/?#dns` in Chrome → click **Clear host cache**.
6. Switch to the **DNS** tab there and look up the host (the page also shows the resolver's view). Then load `https://<host>` — it should hit the local lokl proxy. Reopening `chrome://net-internals/?#dns` after a request should list `127.0.0.1` and/or `::1` for the entry, with no public IP.

## Test plan

- [x] `make check` green.
- [x] Existing `TestHostsManagerBlock` updated to assert both address families.
- [x] New tests: `TestAddEmitsBothAddressFamilies`, `TestBlockIncludesBothAddressFamilies`.
- [x] `TestUnresolvedTrustsHostsBlockWhenWildcardResolverInstalled` still passes — `strings.Fields` parsing handles both line formats identically.

## References

- RFC 8305 — Happy Eyeballs v2
- Chrome 147 stable — 2026-04-28 (when this surfaced)
- `chrome://net-internals/?#dns` — the diagnostic that exposed the public-IPv6 leak