### PR TITLE
fix(lockfile): wait for orphan exit before rebinding ports

### DIFF
--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -14,7 +14,12 @@ import (
 	"github.com/shahin-bayat/lokl/internal/runner"
 )
 
-const killGracePeriod = 5 * time.Second
+const (
+	killGracePeriod = 5 * time.Second
+	// reapTimeout caps how long KillOrphans waits for SIGKILL'd process
+	// groups to vanish (and release their ports) before returning.
+	reapTimeout = 3 * time.Second
+)
 
 type Entry struct {
 	PID        int            `json:"pid"`
@@ -74,10 +79,35 @@ func IsStale(e *Entry) bool {
 	return errors.Is(err, syscall.ESRCH)
 }
 
-// KillOrphans SIGKILLs services from a stale lock (parent already dead).
+// KillOrphans SIGKILLs services from a stale lock (parent already dead) and
+// waits for them to exit, so the caller can rebind their ports without racing
+// the kernel's socket teardown.
 func KillOrphans(e *Entry) {
 	signalProcesses(e, syscall.SIGKILL)
+	waitProcessesGone(e, reapTimeout)
 	stopContainers(e)
+}
+
+// waitProcessesGone polls until every recorded process group is gone or the
+// timeout elapses. Kill(-pgid, 0) returns ESRCH once no member survives.
+func waitProcessesGone(e *Entry, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for {
+		alive := false
+		for _, pgid := range e.Processes {
+			if pgid <= 0 {
+				continue
+			}
+			if err := syscall.Kill(-pgid, 0); err == nil {
+				alive = true
+				break
+			}
+		}
+		if !alive || !time.Now().Before(deadline) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 // Kill sends SIGTERM to the parent lokl process and all service PGIDs,

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -2,6 +2,8 @@ package lockfile_test
 
 import (
 	"os"
+	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -102,6 +104,25 @@ func TestIsStale_MissingPID(t *testing.T) {
 	e := &lockfile.Entry{PID: 999999999}
 	if !lockfile.IsStale(e) {
 		t.Error("non-existent PID should be stale")
+	}
+}
+
+// KillOrphans must not return until the process group is actually gone,
+// otherwise the caller races the orphan's socket teardown when rebinding.
+func TestKillOrphansWaitsForExit(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pgid := cmd.Process.Pid // Setpgid => pgid == pid
+	go func() { _, _ = cmd.Process.Wait() }()
+
+	lockfile.KillOrphans(&lockfile.Entry{Processes: map[string]int{"svc": pgid}})
+
+	// Immediately after KillOrphans returns, the group must be gone.
+	if err := syscall.Kill(-pgid, 0); err == nil {
+		t.Fatal("process group still alive after KillOrphans returned")
 	}
 }
 


### PR DESCRIPTION
## Problem

After an unclean exit (terminal close → `SIGHUP`), `lokl up` fails with `port <N> already in use` even though orphan recovery exists:

```
Error: starting web: process web: port 8080 already in use
```

## Root cause

`up`-time recovery (`KillOrphans`) sent `SIGKILL` and returned **immediately**. `up.go` then removed the lockfile and called `sup.Start()` while the kernel was still tearing down the orphan's listening socket → `EADDRINUSE`. The orphan died a few ms later (too late), and the lockfile was already consumed, so a retry had no record to recover from either.

PR #50's "reliable kill" only hardened the `lokl down` path (`Kill`, which sleeps for the grace period). `KillOrphans` had no wait at all.

## Fix

`KillOrphans` now polls `Kill(-pgid, 0)` until each process group is gone (3s cap) before returning, so the port is actually free when `up` rebinds.

## Verification

- Reproduced the exact failure on the old binary (start → `SIGHUP` → orphan survives → `up` fails to bind).
- Confirmed the patched binary recovers cleanly: orphan reaped, service starts, no manual port-killing.
- New regression test `TestKillOrphansWaitsForExit` asserts the group is gone the instant `KillOrphans` returns.
- `make check` green.